### PR TITLE
Bug 537656: Consider image existence and allow proper positioning of edit widget in XViewerEditAdapter 

### DIFF
--- a/widgets/xviewer/org.eclipse.nebula.widgets.xviewer/src/org/eclipse/nebula/widgets/xviewer/edit/XViewerEditAdapter.java
+++ b/widgets/xviewer/org.eclipse.nebula.widgets.xviewer/src/org/eclipse/nebula/widgets/xviewer/edit/XViewerEditAdapter.java
@@ -43,8 +43,8 @@ public class XViewerEditAdapter {
    public XViewerEditAdapter(XViewerControlFactory factory, XViewerConverter converter) {
       this.factory = factory;
       this.converter = converter;
-
       this.orientationStyle = SWT.RIGHT;
+      
       this.swtEvent = SWT.MouseDown;
    }
 
@@ -234,95 +234,95 @@ public class XViewerEditAdapter {
    private static boolean InInput = false;
 
    void getInput(Control c) {
-	      if (InInput) {
-	         return;
-	      }
-	      if (klickedCell == null) {
-	         return;
-	      }
-	      XViewerColumn xCol =
-	         xv.getXViewerFactory().getDefaultXViewerColumn(((XViewerColumn) klickedColumn.getData()).getId());
-	      if (xCol instanceof ExtendedViewerColumn) {
-	         ExtendedViewerColumn extendedCol = (ExtendedViewerColumn) xCol;
-	         CellEditDescriptor ced = extendedCol.getCellEditDescriptorMap().get(klickedCell.getElement().getClass());
-	         if (ced == null || ced.getControl() == null) {
-	            return;
-	         }
-	         InInput = true;
-	         try {
-	            Object toModify = getInputToModify();
-	            Object obj = converter.getInput(c, ced, toModify);
-	            if (obj == null) {
-	               refreshElement(toModify);
-	            } else {
-	               refreshElement(obj);
-	            }
-	         } catch (Exception ex) {
-	            // do nothing
-	         } finally {
-	            InInput = false;
-	         }
-	      }
-	   }
+      if (InInput) {
+         return;
+      }
+      if (klickedCell == null) {
+         return;
+      }
+      XViewerColumn xCol =
+         xv.getXViewerFactory().getDefaultXViewerColumn(((XViewerColumn) klickedColumn.getData()).getId());
+      if (xCol instanceof ExtendedViewerColumn) {
+         ExtendedViewerColumn extendedCol = (ExtendedViewerColumn) xCol;
+         CellEditDescriptor ced = extendedCol.getCellEditDescriptorMap().get(klickedCell.getElement().getClass());
+         if (ced == null || ced.getControl() == null) {
+            return;
+         }
+         InInput = true;
+         try {
+            Object toModify = getInputToModify();
+            Object obj = converter.getInput(c, ced, toModify);
+            if (obj == null) {
+               refreshElement(toModify);
+            } else {
+               refreshElement(obj);
+            }
+         } catch (Exception ex) {
+            // do nothing
+         } finally {
+            InInput = false;
+         }
+      }
+   }
 
-	   void refreshElement(Object toRefresh) {
-	      xv.refresh(toRefresh);
-	   }
+   void refreshElement(Object toRefresh) {
+      xv.refresh(toRefresh);
+   }
 
-	   Object getInputToModify() {
-	      return klickedCell.getElement();
-	   }
+   Object getInputToModify() {
+      return klickedCell.getElement();
+   }
 
-	   void setInput(Control c) {
-	      if (klickedCell == null) {
-	         return;
-	      }
-	      boolean fitInCell = true;
-	      XViewerColumn xCol =
-	         xv.getXViewerFactory().getDefaultXViewerColumn(((XViewerColumn) klickedColumn.getData()).getId());
-	      if (xCol instanceof ExtendedViewerColumn) {
-	         ExtendedViewerColumn extendedCol = (ExtendedViewerColumn) xCol;
-	         CellEditDescriptor ced = extendedCol.getCellEditDescriptorMap().get(klickedCell.getElement().getClass());
-	         if (ced == null || ced.getControl() == null) {
-	            return;
-	         }
-	         converter.setInput(c, ced, klickedCell.getElement());
-	         fitInCell = ced.isFitInCell();
-	      }
-	      if (fitInCell) {
-	    	  //if there is an image then enable editor control
-	    	  //only if clicked outside image (after the 18th pixel)
-	    	  if (klickedCell.getImage() != null) {
-	    		  Rectangle bounds = klickedCell.getBounds();
-	    		  bounds.x = bounds.x + 18;
-	    		  c.setBounds(bounds);
-	    	  } else {
-	    		  c.setBounds(klickedCell.getBounds());
-	    	  }
-	      } else {
-	         Rectangle bounds = klickedCell.getBounds();
-	         Point point = c.getSize();
-	         //Point point = c.computeSize(SWT.DEFAULT, SWT.DEFAULT);
-	         //consider size from left to write in x-axis
-	         if (orientationStyle == SWT.RIGHT_TO_LEFT
-	        		 || orientationStyle == SWT.RIGHT) {
-	        	 bounds.x = bounds.x + bounds.width - point.x;
-	         }
-	         bounds.width = point.x;
-	         bounds.height = point.y;
-	         c.setBounds(bounds);
-	      }
-	   }
-	   
-	   /**
-	    * controls the positioning of  the input control in the
-	    * case the CellEditDescriptor Control does not take up
-	    * the whole cell space. Default value assumes right
-	    * placement.
-	    *    
-	    * @param style
-	    */
-	   public void setInputControlOrientation(int style) {
-		   orientationStyle = style;
-	   }
+   void setInput(Control c) {
+      if (klickedCell == null) {
+         return;
+      }
+      boolean fitInCell = true;
+      XViewerColumn xCol =
+         xv.getXViewerFactory().getDefaultXViewerColumn(((XViewerColumn) klickedColumn.getData()).getId());
+      if (xCol instanceof ExtendedViewerColumn) {
+         ExtendedViewerColumn extendedCol = (ExtendedViewerColumn) xCol;
+         CellEditDescriptor ced = extendedCol.getCellEditDescriptorMap().get(klickedCell.getElement().getClass());
+         if (ced == null || ced.getControl() == null) {
+            return;
+         }
+         converter.setInput(c, ced, klickedCell.getElement());
+         fitInCell = ced.isFitInCell();
+      }
+      if (fitInCell) {
+    	  //if there is an image then enable editor control
+    	  //only if clicked outside image (after the 18th pixel)
+    	  if (klickedCell.getImage() != null) {
+    		  Rectangle bounds = klickedCell.getBounds();
+    		  bounds.x = bounds.x + 18;
+    		  c.setBounds(bounds);
+    	  } else {
+    		  c.setBounds(klickedCell.getBounds());
+    	  }
+      } else {
+         Rectangle bounds = klickedCell.getBounds();
+         Point point = c.getSize();
+         //Point point = c.computeSize(SWT.DEFAULT, SWT.DEFAULT);
+         //consider size from left to write in x-axis
+         if (orientationStyle == SWT.RIGHT_TO_LEFT
+        		 || orientationStyle == SWT.RIGHT) {
+        	 bounds.x = bounds.x + bounds.width - point.x;
+         }
+         bounds.width = point.x;
+         bounds.height = point.y;
+         c.setBounds(bounds);
+      }
+   }
+   
+   /**
+    * controls the positioning of  the input control in the
+    * case the CellEditDescriptor Control does not take up
+    * the whole cell space. Default value assumes right
+    * placement.
+    *    
+    * @param style
+    */
+   public void setInputControlOrientation(int style) {
+	   orientationStyle = style;
+   }
 }

--- a/widgets/xviewer/org.eclipse.nebula.widgets.xviewer/src/org/eclipse/nebula/widgets/xviewer/edit/XViewerEditAdapter.java
+++ b/widgets/xviewer/org.eclipse.nebula.widgets.xviewer/src/org/eclipse/nebula/widgets/xviewer/edit/XViewerEditAdapter.java
@@ -28,6 +28,8 @@ public class XViewerEditAdapter {
    ViewerCell klickedCell;
    TreeColumn klickedColumn;
 
+   int orientationStyle;
+   
    final XViewerControlFactory factory;
    final XViewerConverter converter;
 
@@ -42,6 +44,7 @@ public class XViewerEditAdapter {
       this.factory = factory;
       this.converter = converter;
 
+      this.orientationStyle = SWT.RIGHT;
       this.swtEvent = SWT.MouseDown;
    }
 
@@ -231,69 +234,95 @@ public class XViewerEditAdapter {
    private static boolean InInput = false;
 
    void getInput(Control c) {
-      if (InInput) {
-         return;
-      }
-      if (klickedCell == null) {
-         return;
-      }
-      XViewerColumn xCol =
-         xv.getXViewerFactory().getDefaultXViewerColumn(((XViewerColumn) klickedColumn.getData()).getId());
-      if (xCol instanceof ExtendedViewerColumn) {
-         ExtendedViewerColumn extendedCol = (ExtendedViewerColumn) xCol;
-         CellEditDescriptor ced = extendedCol.getCellEditDescriptorMap().get(klickedCell.getElement().getClass());
-         if (ced == null || ced.getControl() == null) {
-            return;
-         }
-         InInput = true;
-         try {
-            Object toModify = getInputToModify();
-            Object obj = converter.getInput(c, ced, toModify);
-            if (obj == null) {
-               refreshElement(toModify);
-            } else {
-               refreshElement(obj);
-            }
-         } catch (Exception ex) {
-            // do nothing
-         } finally {
-            InInput = false;
-         }
-      }
-   }
+	      if (InInput) {
+	         return;
+	      }
+	      if (klickedCell == null) {
+	         return;
+	      }
+	      XViewerColumn xCol =
+	         xv.getXViewerFactory().getDefaultXViewerColumn(((XViewerColumn) klickedColumn.getData()).getId());
+	      if (xCol instanceof ExtendedViewerColumn) {
+	         ExtendedViewerColumn extendedCol = (ExtendedViewerColumn) xCol;
+	         CellEditDescriptor ced = extendedCol.getCellEditDescriptorMap().get(klickedCell.getElement().getClass());
+	         if (ced == null || ced.getControl() == null) {
+	            return;
+	         }
+	         InInput = true;
+	         try {
+	            Object toModify = getInputToModify();
+	            Object obj = converter.getInput(c, ced, toModify);
+	            if (obj == null) {
+	               refreshElement(toModify);
+	            } else {
+	               refreshElement(obj);
+	            }
+	         } catch (Exception ex) {
+	            // do nothing
+	         } finally {
+	            InInput = false;
+	         }
+	      }
+	   }
 
-   void refreshElement(Object toRefresh) {
-      xv.refresh(toRefresh);
-   }
+	   void refreshElement(Object toRefresh) {
+	      xv.refresh(toRefresh);
+	   }
 
-   Object getInputToModify() {
-      return klickedCell.getElement();
-   }
+	   Object getInputToModify() {
+	      return klickedCell.getElement();
+	   }
 
-   void setInput(Control c) {
-      if (klickedCell == null) {
-         return;
-      }
-      boolean fitInCell = true;
-      XViewerColumn xCol =
-         xv.getXViewerFactory().getDefaultXViewerColumn(((XViewerColumn) klickedColumn.getData()).getId());
-      if (xCol instanceof ExtendedViewerColumn) {
-         ExtendedViewerColumn extendedCol = (ExtendedViewerColumn) xCol;
-         CellEditDescriptor ced = extendedCol.getCellEditDescriptorMap().get(klickedCell.getElement().getClass());
-         if (ced == null || ced.getControl() == null) {
-            return;
-         }
-         converter.setInput(c, ced, klickedCell.getElement());
-         fitInCell = ced.isFitInCell();
-      }
-      if (fitInCell) {
-         c.setBounds(klickedCell.getBounds());
-      } else {
-         Rectangle bounds = klickedCell.getBounds();
-         Point point = c.computeSize(SWT.DEFAULT, SWT.DEFAULT);
-         bounds.width = point.x;
-         bounds.height = point.y;
-         c.setBounds(bounds);
-      }
-   }
+	   void setInput(Control c) {
+	      if (klickedCell == null) {
+	         return;
+	      }
+	      boolean fitInCell = true;
+	      XViewerColumn xCol =
+	         xv.getXViewerFactory().getDefaultXViewerColumn(((XViewerColumn) klickedColumn.getData()).getId());
+	      if (xCol instanceof ExtendedViewerColumn) {
+	         ExtendedViewerColumn extendedCol = (ExtendedViewerColumn) xCol;
+	         CellEditDescriptor ced = extendedCol.getCellEditDescriptorMap().get(klickedCell.getElement().getClass());
+	         if (ced == null || ced.getControl() == null) {
+	            return;
+	         }
+	         converter.setInput(c, ced, klickedCell.getElement());
+	         fitInCell = ced.isFitInCell();
+	      }
+	      if (fitInCell) {
+	    	  //if there is an image then enable editor control
+	    	  //only if clicked outside image (after the 18th pixel)
+	    	  if (klickedCell.getImage() != null) {
+	    		  Rectangle bounds = klickedCell.getBounds();
+	    		  bounds.x = bounds.x + 18;
+	    		  c.setBounds(bounds);
+	    	  } else {
+	    		  c.setBounds(klickedCell.getBounds());
+	    	  }
+	      } else {
+	         Rectangle bounds = klickedCell.getBounds();
+	         Point point = c.getSize();
+	         //Point point = c.computeSize(SWT.DEFAULT, SWT.DEFAULT);
+	         //consider size from left to write in x-axis
+	         if (orientationStyle == SWT.RIGHT_TO_LEFT
+	        		 || orientationStyle == SWT.RIGHT) {
+	        	 bounds.x = bounds.x + bounds.width - point.x;
+	         }
+	         bounds.width = point.x;
+	         bounds.height = point.y;
+	         c.setBounds(bounds);
+	      }
+	   }
+	   
+	   /**
+	    * controls the positioning of  the input control in the
+	    * case the CellEditDescriptor Control does not take up
+	    * the whole cell space. Default value assumes right
+	    * placement.
+	    *    
+	    * @param style
+	    */
+	   public void setInputControlOrientation(int style) {
+		   orientationStyle = style;
+	   }
 }


### PR DESCRIPTION
The pull requests improves XViewerEditAdapter by:
- allowing positioning of control widget in case CellEditDescriptor fitInCell option is set to false
- disables activation of cell editor in the first 18 pixels in case an image is present (thus allowing clicking of images even in case of editable cells)

*  https://bugs.eclipse.org/bugs/show_bug.cgi?id=537656

Signed-off-by: Nikolaos Pringouris <nprigour@gmail.com>