### PR TITLE
Fix bug 534270 (Unexpected padding to right of RoundedToolItems when RoundedToolbar has SWT.HIDE_SELECTIO)

### DIFF
--- a/widgets/opal/roundedtoolbar/org.eclipse.nebula.widgets.opal.roundedtoolbar.snippets/src/org/eclipse/nebula/widgets/opal/roundedtoolbar/snippets/RoundedToolbarSnippet.java
+++ b/widgets/opal/roundedtoolbar/org.eclipse.nebula.widgets.opal.roundedtoolbar.snippets/src/org/eclipse/nebula/widgets/opal/roundedtoolbar/snippets/RoundedToolbarSnippet.java
@@ -243,7 +243,7 @@ public class RoundedToolbarSnippet {
 		final RoundedToolItem mailItem = new RoundedToolItem(toolBar, SWT.RADIO);
 		mailItem.setSelectionImage(emailw);
 		mailItem.setImage(emailb);
-		mailItem.setWidth(50);
+		mailItem.setWidth(drawRadio ? 50 : 32);
 		mailItem.addListener(SWT.Selection, e -> {
 			System.out.println("radio/Button 1");
 		});
@@ -256,7 +256,7 @@ public class RoundedToolbarSnippet {
 		mailItemWithText.setText("Mails");
 		mailItemWithText.setSelectionImage(emailw);
 		mailItemWithText.setImage(emailb);
-		mailItemWithText.setWidth(80);
+		mailItemWithText.setWidth(drawRadio ? 80 : 65);
 		mailItemWithText.addListener(SWT.Selection, e -> {
 			System.out.println("radio/Button 2");
 		});

--- a/widgets/opal/roundedtoolbar/org.eclipse.nebula.widgets.opal.roundedtoolbar/src/org/eclipse/nebula/widgets/opal/roundedtoolbar/RoundedToolItem.java
+++ b/widgets/opal/roundedtoolbar/org.eclipse.nebula.widgets.opal.roundedtoolbar/src/org/eclipse/nebula/widgets/opal/roundedtoolbar/RoundedToolItem.java
@@ -278,7 +278,7 @@ public class RoundedToolItem extends Item {
 	}
 
 	private int getAdditionnalWidth() {
-		if (isCheckbox() || isRadio()) {
+		if (isCheckbox() || isRadio() && !hideSelection) {
 			return 16;
 		}
 		return 0;


### PR DESCRIPTION
When using SWT.RADIO buttons and SWT.HIDE_SELECTION on the toolbar,
there's some unexpected space/padding to the right hand side of the
icon. (perhaps also with other styles, didn't try!)

You can actually see this on the Wiki screenshots at
https://wiki.eclipse.org/Nebula_RoundedToolbar.

We'd ideally want SWT.HIDE_SELECTION to look like the regular TOGGLE
case.