### PR TITLE
Bug 540967 - Inverted axis tick labelling bug

### DIFF
--- a/widgets/visualization/org.eclipse.nebula.visualization.xygraph.exampleview/src/org/eclipse/nebula/visualization/xygraph/exampleview/PureJavaExample.java
+++ b/widgets/visualization/org.eclipse.nebula.visualization.xygraph.exampleview/src/org/eclipse/nebula/visualization/xygraph/exampleview/PureJavaExample.java
@@ -10,6 +10,7 @@ package org.eclipse.nebula.visualization.xygraph.exampleview;
 
 import org.eclipse.draw2d.LightweightSystem;
 import org.eclipse.nebula.visualization.xygraph.dataprovider.CircularBufferDataProvider;
+import org.eclipse.nebula.visualization.xygraph.figures.DAxesFactory;
 import org.eclipse.nebula.visualization.xygraph.figures.IXYGraph;
 import org.eclipse.nebula.visualization.xygraph.figures.ToolbarArmedXYGraph;
 import org.eclipse.nebula.visualization.xygraph.figures.Trace;
@@ -32,7 +33,7 @@ public class PureJavaExample {
 		final LightweightSystem lws = new LightweightSystem(shell);
 
 		// create a new XY Graph.
-		IXYGraph xyGraph = new XYGraph();
+		IXYGraph xyGraph = new XYGraph(new DAxesFactory());
 
 		ToolbarArmedXYGraph toolbarArmedXYGraph = new ToolbarArmedXYGraph(xyGraph);
 
@@ -42,13 +43,17 @@ public class PureJavaExample {
 
 		xyGraph.getPrimaryXAxis().setShowMajorGrid(true);
 		xyGraph.getPrimaryYAxis().setShowMajorGrid(true);
+		xyGraph.getPrimaryXAxis().setAutoScale(true);
+		xyGraph.getPrimaryYAxis().setAutoScale(true);
+		xyGraph.getPrimaryXAxis().setInverted(true);
+		xyGraph.getPrimaryYAxis().setInverted(true);
 
 		// create a trace data provider, which will provide the data to the
 		// trace.
 		CircularBufferDataProvider traceDataProvider = new CircularBufferDataProvider(false);
 		traceDataProvider.setBufferSize(100);
-		traceDataProvider.setCurrentXDataArray(new double[] { 10, 23, 34, 45, 56, 78, 88, 99 });
-		traceDataProvider.setCurrentYDataArray(new double[] { 11, 44, 55, 45, 88, 98, 52, 23 });
+		traceDataProvider.setCurrentXDataArray(new double[] { -0.2, 23, 34, 45, 56, 78, 88, 100.1 });
+		traceDataProvider.setCurrentYDataArray(new double[] { -0.5, 44, 55, 45, 88, 100.1, 52, 23 });
 
 		// create the trace
 		Trace trace = new Trace("Trace1-XY Plot", xyGraph.getPrimaryXAxis(), xyGraph.getPrimaryYAxis(), traceDataProvider);
@@ -64,6 +69,5 @@ public class PureJavaExample {
 			if (!display.readAndDispatch())
 				display.sleep();
 		}
-
 	}
 }

--- a/widgets/visualization/org.eclipse.nebula.visualization.xygraph/src/org/eclipse/nebula/visualization/xygraph/linearscale/LinearScaleTicks2.java
+++ b/widgets/visualization/org.eclipse.nebula.visualization.xygraph/src/org/eclipse/nebula/visualization/xygraph/linearscale/LinearScaleTicks2.java
@@ -198,18 +198,19 @@ public class LinearScaleTicks2 implements ITicksProvider {
 			} else {
 				ticks = tf.generateTicks(min, max, numTicks, true, !scale.hasTicksAtEnds());
 			}
-		} while (!updateLabelPositionsAndCheckGaps(length, hMargin, tMargin, min > max) && numTicks-- > MIN_TICKS);
+		} while (!updateLabelPositionsAndCheckGaps(length, hMargin, tMargin) && numTicks-- > MIN_TICKS);
 
 		updateMinorTicks(hMargin + length);
 		if (scale.hasTicksAtEnds() && ticks.size() > 1) {
 			// check for extreme case where outer ticks has been placed inside
 			// requested range owing to their magnitude exceeding Double.MAX_VALUE
+			boolean isInverted = min > max;
 			double lo = ticks.get(0).getValue();
-			if (min < lo) {
+			if (isInverted ^ (lo > min)) {
 				lo = min;
 			}
 			double hi = ticks.get(ticks.size() - 1).getValue();
-			if (max > hi) {
+			if (isInverted ^ (hi < max)) {
 				hi = max;
 			}
 			return new Range(lo, hi);
@@ -278,8 +279,7 @@ public class LinearScaleTicks2 implements ITicksProvider {
 	 *
 	 * @return true if there is no overlaps
 	 */
-	private boolean updateLabelPositionsAndCheckGaps(int length, final int hMargin, final int tMargin,
-			final boolean isReversed) {
+	private boolean updateLabelPositionsAndCheckGaps(int length, final int hMargin, final int tMargin) {
 		final int imax = ticks.size();
 		if (imax == 0) {
 			return true;
@@ -305,15 +305,10 @@ public class LinearScaleTicks2 implements ITicksProvider {
 			}
 		}
 
-		if (isReversed) {
-			for (Tick t : ticks) {
-				t.setPosition(length - length * t.getPosition() + hMargin);
-			}
-		} else {
-			for (Tick t : ticks) {
-				t.setPosition(length * t.getPosition() + hMargin);
-			}
+		for (Tick t : ticks) {
+			t.setPosition(length * t.getPosition() + hMargin);
 		}
+
 		// re-expand length (so labels can flow into margins)
 		length += hMargin + tMargin;
 		if (scale.isHorizontal()) {

--- a/widgets/visualization/org.eclipse.nebula.visualization.xygraph/src/org/eclipse/nebula/visualization/xygraph/linearscale/TickFactory.java
+++ b/widgets/visualization/org.eclipse.nebula.visualization.xygraph/src/org/eclipse/nebula/visualization/xygraph/linearscale/TickFactory.java
@@ -489,23 +489,25 @@ public class TickFactory {
 
 		// override tight flag in cases where graph ends have been
 		// modified (in determineNumTicks) to be representable as doubles
-		double lo = tight || min < graphMin ? min : ticks.get(0).getValue();
-		double hi = tight || max > graphMax ? max : (imax > 1 ? ticks.get(imax - 1).getValue() : lo);
+		double lo = tight || compare(isReversed, min, graphMin) ? min : ticks.get(0).getValue();
+		double hi = tight || compare(!isReversed, max, graphMax) ? max : (imax > 1 ? ticks.get(imax - 1).getValue() : lo);
 		double factor = LargeNumberUtils.maxMagnitude(lo, hi);
 		lo /= factor;
 		hi /= factor;
 		double range = imax > 1 ? hi - lo : 1;
 
-		if (isReversed) {
-			for (Tick t : ticks) {
-				t.setPosition(1 - (t.getValue()/factor - lo) / range);
-			}
-		} else {
-			for (Tick t : ticks) {
-				t.setPosition((t.getValue()/factor - lo) / range);
-			}
+		for (Tick t : ticks) {
+			t.setPosition((t.getValue()/factor - lo) / range);
 		}
+
 		return ticks;
+	}
+
+	private static boolean compare(boolean isGreaterThan, double a, double b) {
+		if (isGreaterThan) {
+			return a > b;
+		}
+		return a < b;
 	}
 
 	private static final DecimalFormat INDEX_FORMAT = new DecimalFormat("0");


### PR DESCRIPTION
When an axis is inverted, the end points are miscalculated leading to strange appearance of tick labels

Modify check for end condition, simplify position calculation, add inverted check to new range, and add unit tests
