### PR TITLE
Bug 507140 - SWTException below GalleryItem.setImage

### DIFF
--- a/widgets/gallery/org.eclipse.nebula.widgets.gallery/src/org/eclipse/nebula/widgets/gallery/GalleryItem.java
+++ b/widgets/gallery/org.eclipse.nebula.widgets.gallery/src/org/eclipse/nebula/widgets/gallery/GalleryItem.java
@@ -158,7 +158,8 @@ public class GalleryItem extends Item {
 
 	}
 
-	protected GalleryItem(Gallery parent, int style, int index, boolean create) {
+	protected GalleryItem(Gallery parent, int style, int index,
+			boolean create) {
 		super(parent, style);
 		this.parent = parent;
 		this.parentItem = null;
@@ -266,6 +267,10 @@ public class GalleryItem extends Item {
 	}
 
 	public void setImage(Image image) {
+		checkWidget();
+		if (image != null && image.isDisposed()) {
+			SWT.error(SWT.ERROR_INVALID_ARGUMENT);
+		}
 		super.setImage(image);
 		parent.redraw(this);
 	}


### PR DESCRIPTION
Method setImage:
The check (Widget is Disposed) was done in the super() method.
I propose to check before the call to the super method.