### PR TITLE
Bug 514731 TableCombo sends a selection event on each opening of the

### DIFF
--- a/widgets/tablecombo/org.eclipse.nebula.widgets.tablecombo/src/org/eclipse/nebula/widgets/tablecombo/TableCombo.java
+++ b/widgets/tablecombo/org.eclipse.nebula.widgets.tablecombo/src/org/eclipse/nebula/widgets/tablecombo/TableCombo.java
@@ -535,9 +535,7 @@ public class TableCombo extends Composite {
 			if (focusControl == arrow || focusControl == table) {
 				return;
 			}
-			if (isDropped()) {
-				table.setFocus();
-			} else {
+			if (!isDropped()) {
 				text.setFocus();
 			}
 			break;
@@ -844,8 +842,6 @@ public class TableCombo extends Composite {
 		// set the popup visible
 		popup.setVisible(true);
 
-		// set focus on the table.
-		table.setFocus();
 	}
 
 	/*


### PR DESCRIPTION
drop down box

Remove obsolete call to table.setFocus() on drop down

Signed-off-by: Matthias Paul Scholz <matthias.paul.scholz@gmail.com>