### PR TITLE
Bug 543565 fix leak of annotations

### DIFF
--- a/widgets/visualization/org.eclipse.nebula.visualization.xygraph/src/org/eclipse/nebula/visualization/xygraph/figures/Annotation.java
+++ b/widgets/visualization/org.eclipse.nebula.visualization.xygraph/src/org/eclipse/nebula/visualization/xygraph/figures/Annotation.java
@@ -175,6 +175,16 @@ public class Annotation extends Figure implements IAxisListener, IDataProviderLi
 		yAxis.addListener(this);
 	}
 
+	public void remove() {
+		if (listeners != null) {
+			listeners.clear();
+			listeners = null;
+		}
+		if (getParent()!=null) getParent().remove(this);
+		xAxis.removeListener(this);
+		yAxis.removeListener(this);
+	}
+
 	public synchronized void addAnnotationListener(IAnnotationListener listener) {
 		if (listeners == null)
 			listeners = new CopyOnWriteArrayList<IAnnotationListener>();

--- a/widgets/visualization/org.eclipse.nebula.visualization.xygraph/src/org/eclipse/nebula/visualization/xygraph/figures/PlotArea.java
+++ b/widgets/visualization/org.eclipse.nebula.visualization.xygraph/src/org/eclipse/nebula/visualization/xygraph/figures/PlotArea.java
@@ -235,7 +235,7 @@ public class PlotArea extends Figure {
 			}
 		}
 		if (result) {
-			remove(annotation);
+			annotation.remove();
 			revalidate();
 
 			// Laurent PHILIPPE send event


### PR DESCRIPTION
Fix leak of annotations caused by them not being removed listeners to their axes

Change-Id: I8e7c88ba92bea460c0f8b9275737755bce4206e8
Signed-off-by: Peter Chang <peter.chang@diamond.ac.uk>