### PR TITLE
Bug 544177 - Support customizing regex for word boundaries

### DIFF
--- a/widgets/richtext/org.eclipse.nebula.widgets.richtext.example/src/org/eclipse/nebula/widgets/richtext/example/RichTextViewerExample.java
+++ b/widgets/richtext/org.eclipse.nebula.widgets.richtext.example/src/org/eclipse/nebula/widgets/richtext/example/RichTextViewerExample.java
@@ -55,6 +55,7 @@ public class RichTextViewerExample {
 		GridDataFactory.fillDefaults().grab(true, true).applyTo(editor);
 
 		final RichTextViewer viewer = new RichTextViewer(parent, SWT.BORDER | SWT.WRAP);
+		viewer.setWordSplitRegex("\\s|\\-");//wrap after whitespace characters and delimiter
 		GridDataFactory.fillDefaults().grab(true, true).span(1, 2).applyTo(viewer);
 
 		final Text htmlOutput = new Text(parent,

--- a/widgets/richtext/org.eclipse.nebula.widgets.richtext/src/org/eclipse/nebula/widgets/richtext/RichTextCellLabelProvider.java
+++ b/widgets/richtext/org.eclipse.nebula.widgets.richtext/src/org/eclipse/nebula/widgets/richtext/RichTextCellLabelProvider.java
@@ -47,9 +47,14 @@ public abstract class RichTextCellLabelProvider<T> extends StyledCellLabelProvid
 	}
 
 	public RichTextCellLabelProvider(final Control viewerControl, final int leftRightMargin, boolean wordWrap) {
+		this(viewerControl, leftRightMargin, wordWrap, "\\s");
+	}
+	
+	public RichTextCellLabelProvider(final Control viewerControl, final int leftRightMargin, boolean wordWrap, String wordSplitRegex) {
 		super(COLORS_ON_SELECTION);
 
 		this.painter = new RichTextPainter(wordWrap);
+		painter.setWordSplitRegex(wordSplitRegex);
 
 		if (viewerControl instanceof Tree) {
 			viewerControl.addListener(SWT.MeasureItem, new Listener() {

--- a/widgets/richtext/org.eclipse.nebula.widgets.richtext/src/org/eclipse/nebula/widgets/richtext/RichTextPainter.java
+++ b/widgets/richtext/org.eclipse.nebula.widgets.richtext/src/org/eclipse/nebula/widgets/richtext/RichTextPainter.java
@@ -118,6 +118,8 @@ public class RichTextPainter {
 	}
 
 	private EntityReplacer entityReplacer = new DefaultEntityReplacer();
+	
+	private String wordSplitRegex = "\\s";
 
 	/**
 	 * Create a new {@link RichTextPainter} with disabled word wrapping.
@@ -482,7 +484,7 @@ public class RichTextPainter {
 					// if word wrapping is enabled, split the text and create new lines
 					// by making several TextPaintInstructions with substrings
 
-					Deque<String> wordsToProcess = new LinkedList<>(Arrays.asList(txtInstr.getText().split("(?<=\\s)")));
+					Deque<String> wordsToProcess = new LinkedList<>(Arrays.asList(txtInstr.getText().split("(?<=" + wordSplitRegex + ")")));
 					String subString = "";
 					int subStringLength = 0;
 					while (!wordsToProcess.isEmpty()) {
@@ -717,5 +719,14 @@ public class RichTextPainter {
 	 */
 	public void setParagraphSpace(int paragraphSpace) {
 		this.paragraphSpace = paragraphSpace;
+	}
+	
+	/**
+	 * @param wordSplitRegex
+	 *            The regular expression that will be used to determine word boundaries. The default
+	 *            is "\s".
+	 */
+	public void setWordSplitRegex(String wordSplitRegex) {
+		this.wordSplitRegex = wordSplitRegex;
 	}
 }

--- a/widgets/richtext/org.eclipse.nebula.widgets.richtext/src/org/eclipse/nebula/widgets/richtext/RichTextViewer.java
+++ b/widgets/richtext/org.eclipse.nebula.widgets.richtext/src/org/eclipse/nebula/widgets/richtext/RichTextViewer.java
@@ -59,4 +59,16 @@ public class RichTextViewer extends Canvas {
 		redraw();
 		update();
 	}
+	
+	/**
+	 * @param wordSplitRegex
+	 *            The regular expression that will be used to determine word boundaries.
+	 */
+	public void setWordSplitRegex(String wordSplitRegex) {
+		painter.setWordSplitRegex(wordSplitRegex);
+		if (htmlText != null) {
+			redraw();
+			update();
+		}
+	}
 }

--- a/widgets/richtext/org.eclipse.nebula.widgets.richtext/src/org/eclipse/nebula/widgets/richtext/painter/instructions/TextPaintInstruction.java
+++ b/widgets/richtext/org.eclipse.nebula.widgets.richtext/src/org/eclipse/nebula/widgets/richtext/painter/instructions/TextPaintInstruction.java
@@ -34,13 +34,17 @@ public class TextPaintInstruction implements PaintInstruction {
 	private List<String> words = new ArrayList<>();
 
 	public TextPaintInstruction(TagProcessingState state, String text) {
+		this(state, text, "\\s");
+	}
+
+	public TextPaintInstruction(TagProcessingState state, String text, String wordSplitRegex) {
 		this.state = state;
 		this.text = text;
 
 		// extract and store the trimmed words in the text
 		String word = text.trim();
 		if (word.length() > 0) {
-			String[] splitText = word.split("\\s");
+			String[] splitText = word.split(wordSplitRegex);
 			for (String splitWord : splitText) {
 				String trimmed = splitWord.trim();
 				if (trimmed.length() > 0) {
@@ -80,8 +84,7 @@ public class TextPaintInstruction implements PaintInstruction {
 				pointer.x += length;
 				textLength += length;
 			}
-		}
-		else {
+		} else {
 			textLength = getTextLength(gc);
 			gc.drawText(text, pointer.x, pointer.y + yAdvance, (!this.state.hasPreviousBgColor()));
 		}


### PR DESCRIPTION
This is a first draft. I added this to the RichTextViewerExample for testing. I am not sure about unit testing (I think currently there are none?) and about Since-Tags. 

Changes:
* Additional constructor for RichTextCellLabelProvider, RichTextPainter,
and TextPaintInstruction to pass in a regex
* Setter for RichTextPainter, and RichTextViewer to pass in a regex
* Adjust RichTextViewerExample to split after whitespace characters on
on "-"