### PR TITLE
Issue 41 - ProgressCircle requires a specific SWT version

### DIFF
--- a/widgets/progresscircle/org.eclipse.nebula.widgets.progresscircle/META-INF/MANIFEST.MF
+++ b/widgets/progresscircle/org.eclipse.nebula.widgets.progresscircle/META-INF/MANIFEST.MF
@@ -6,5 +6,5 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.nebula.widgets.progresscircle
-Require-Bundle: org.eclipse.swt;bundle-version="3.106.1";visibility:=reexport,
- org.eclipse.equinox.common;bundle-version="3.9.0";visibility:=reexport
+Require-Bundle: org.eclipse.swt,
+ org.eclipse.equinox.common


### PR DESCRIPTION
Remove version for SWT and Equinox Commons bundles, and remove the "reexport" flag