### PR TITLE
Bug 545643 - fix position of inverted index axis

### DIFF
--- a/widgets/visualization/org.eclipse.nebula.visualization.xygraph.test/src/org/eclipse/nebula/visualization/xygraph/linearscale/TickFactoryTest.java
+++ b/widgets/visualization/org.eclipse.nebula.visualization.xygraph.test/src/org/eclipse/nebula/visualization/xygraph/linearscale/TickFactoryTest.java
@@ -308,14 +308,13 @@ public class TickFactoryTest {
 
 	@Test
 	public void testIndexTicks() {
-		testGeneratedIndexBasedTicks(true, 0, 1, 4, "0", "1");
-		testGeneratedIndexBasedTicks(false, 0, 1, 4, "0", "1");
+		testGeneratedIndexBasedTicks(0, 1, 4, "0", "1");
 
-		testGeneratedIndexBasedTicks(true, 0.1, 1, 4, "1");
-		testGeneratedIndexBasedTicks(false, 0.1, 1, 4, "1");
+		testGeneratedIndexBasedTicks(0, 3, 4, "0", "2");
 
-		testGeneratedIndexBasedTicks(true, 0.1, 0.9, 4);
-		testGeneratedIndexBasedTicks(false, 0.1, 0.9, 4);
+		testGeneratedIndexBasedTicks(0.1, 1, 4, "1");
+
+		testGeneratedIndexBasedTicks(0.1, 0.9, 4);
 	}
 
 	@Test
@@ -465,26 +464,31 @@ public class TickFactoryTest {
 		checkTickValues(t, out);
 
 		if (upper != lower) {
+			List<Tick> ot = t;
 			t = tf.generateLogTicks(upper, lower, nTicks, true, tight);
-			for (int i = 0; i < out.length; i++)
+			for (int i = 0; i < out.length; i++) {
 				values[i] = out[out.length - 1 - i];
+			}
 			checkTickValues(t, values);
+			if (!tight) {
+				checkTickPositions(ot, t);
+			}
 		}
 	}
 
-	private void testGeneratedIndexBasedTicks(boolean tight, double lower, double upper, int nTicks,
-			final String... out) {
+	private void testGeneratedIndexBasedTicks(double lower, double upper, int nTicks, final String... out) {
 		TickFactory tf = new TickFactory(TickFormatting.autoMode, null);
 		String[] values = new String[out.length];
 		List<Tick> t;
 
-		t = tf.generateIndexBasedTicks(lower, upper, nTicks, tight);
+		t = tf.generateIndexBasedTicks(lower, upper, nTicks);
 		checkTickValues(t, out);
 
 		if (upper != lower) {
-			t = tf.generateIndexBasedTicks(upper, lower, nTicks, tight);
-			for (int i = 0; i < out.length; i++)
+			t = tf.generateIndexBasedTicks(upper, lower, nTicks);
+			for (int i = 0; i < out.length; i++) {
 				values[i] = out[out.length - 1 - i];
+			}
 			checkTickValues(t, values);
 		}
 	}

--- a/widgets/visualization/org.eclipse.nebula.visualization.xygraph/src/org/eclipse/nebula/visualization/xygraph/linearscale/LinearScaleTicks2.java
+++ b/widgets/visualization/org.eclipse.nebula.visualization.xygraph/src/org/eclipse/nebula/visualization/xygraph/linearscale/LinearScaleTicks2.java
@@ -192,7 +192,7 @@ public class LinearScaleTicks2 implements ITicksProvider {
 		// loop until labels fit
 		do {
 			if (ticksIndexBased) {
-				ticks = tf.generateIndexBasedTicks(min, max, numTicks, !scale.hasTicksAtEnds());
+				ticks = tf.generateIndexBasedTicks(min, max, numTicks);
 			} else if (scale.isLogScaleEnabled()) {
 				ticks = tf.generateLogTicks(min, max, numTicks, true, !scale.hasTicksAtEnds());
 			} else {

--- a/widgets/visualization/org.eclipse.nebula.visualization.xygraph/src/org/eclipse/nebula/visualization/xygraph/linearscale/TickFactory.java
+++ b/widgets/visualization/org.eclipse.nebula.visualization.xygraph/src/org/eclipse/nebula/visualization/xygraph/linearscale/TickFactory.java
@@ -11,7 +11,6 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.nebula.visualization.internal.xygraph.utils.LargeNumberUtils;
@@ -518,11 +517,9 @@ public class TickFactory {
 	 * @param min
 	 * @param max
 	 * @param maxTicks
-	 * @param tight
-	 *            if true then remove ticks outside range (ignored)
 	 * @return a list of the ticks for the axis
 	 */
-	public List<Tick> generateIndexBasedTicks(double min, double max, int maxTicks, boolean tight) {
+	public List<Tick> generateIndexBasedTicks(double min, double max, int maxTicks) {
 		isReversed = min > max;
 		if (isReversed) {
 			double t = max;
@@ -558,21 +555,31 @@ public class TickFactory {
 			break;
 		}
 
+		final double p0;
+		if (isReversed) {
+			p0 = graphMax;
+			tickUnit = -tickUnit;
+		} else {
+			p0 = graphMin;
+		}
 		for (int i = 0; i <= numberOfIntervals; i++) {
-			double p = graphMin + i * tickUnit;
+			double p = p0 + i * tickUnit;
 			Tick newTick = new Tick();
 			newTick.setValue(p);
 			newTick.setText(getTickString(p));
 			ticks.add(newTick);
 		}
 
-		int imax = ticks.size();
-		double range = imax > 1 ? max - min : 1;
-		for (Tick t : ticks) {
-			t.setPosition((t.getValue() - min) / range);
-		}
+		double lo = Math.min(min, graphMin);
+		double hi = Math.max(max, graphMax);
 		if (isReversed) {
-			Collections.reverse(ticks);
+			double t = hi;
+			hi = lo;
+			lo = t;
+		}
+		double range = numberOfIntervals > 0 ? hi - lo: 1;
+		for (Tick t : ticks) {
+			t.setPosition((t.getValue() - lo) / range);
 		}
 
 		if (formatOfTicks == TickFormatting.autoMode) { // override labels
@@ -771,20 +778,11 @@ public class TickFactory {
 			}
 		}
 
-		if (tickUnit > 0) {
-			double lo = Math.log(tight ? min : ticks.get(0).getValue());
-			double hi = Math.log(tight ? max : ticks.get(imax - 1).getValue());
-			double range = hi - lo;
-			for (Tick t : ticks) {
-				t.setPosition((Math.log(t.getValue()) - lo) / range);
-			}
-		} else {
-			double lo = Math.log(tight ? max : ticks.get(0).getValue());
-			double hi = Math.log(tight ? min : ticks.get(imax - 1).getValue());
-			double range = hi - lo;
-			for (Tick t : ticks) {
-				t.setPosition(1 - (Math.log(t.getValue()) - lo) / range);
-			}
+		double lo = Math.log(tight ? min : ticks.get(0).getValue());
+		double hi = Math.log(tight ? max : ticks.get(imax - 1).getValue());
+		double range = hi - lo;
+		for (Tick t : ticks) {
+			t.setPosition((Math.log(t.getValue()) - lo) / range);
 		}
 		return ticks;
 	}


### PR DESCRIPTION
When an axis is inverted and index-based ticks are generate, its positions are not flipped. Remove unused tight argument as it does not apply for index-based ticks. Update tests and add inverted limit check for log ticks.

Change-Id: I73ea7eef914f210c89ff63d61b8cc2cf3ac513aa