### PR TITLE
Bug 546018: Split getBackground method

### DIFF
--- a/widgets/xviewer/org.eclipse.nebula.widgets.xviewer/src/org/eclipse/nebula/widgets/xviewer/XViewerLabelProvider.java
+++ b/widgets/xviewer/org.eclipse.nebula.widgets.xviewer/src/org/eclipse/nebula/widgets/xviewer/XViewerLabelProvider.java
@@ -115,13 +115,22 @@ public abstract class XViewerLabelProvider implements ITableLabelProvider, ITabl
       }
    }
 
+   public Color getSearchBackground(Object element, int columnIndex) {
+      String text = getColumnText(element, columnIndex);
+      if (viewer.searchMatch(text)) {
+         return viewer.getSearchMatchColor();
+      }
+      return null;
+   }
+
    @Override
    public Color getBackground(Object element, int columnIndex) {
       try {
+         Color searchColor = null;
          if (viewer.isSearch()) {
-            String text = getColumnText(element, columnIndex);
-            if (viewer.searchMatch(text)) {
-               return viewer.getSearchMatchColor();
+            searchColor = getSearchBackground(element, columnIndex);
+            if (searchColor != null) {
+               return searchColor;
             }
          }
 


### PR DESCRIPTION
Bug 546018 : XViewer search doesn't highlight lines that are gray

Added a separate method for getting background for content that matches search criteria, outside of the original getBackground method. 

Signed-off-by: Branden Phillips <branden.w.phillips@boeing.com>