### PR TITLE
Bug 289210 - Exceptions thrown by CDateTime

### DIFF
--- a/widgets/cwt/org.eclipse.nebula.cwt/src/org/eclipse/nebula/cwt/base/BaseCombo.java
+++ b/widgets/cwt/org.eclipse.nebula.cwt/src/org/eclipse/nebula/cwt/base/BaseCombo.java
@@ -985,6 +985,9 @@ public abstract class BaseCombo extends Canvas {
 	 * @see BaseCombo#setOpen(boolean, Runnable)
 	 */
 	protected void setOpen(boolean open) {
+		if (open == this.open) {
+			return;
+		}
 		setOpen(open, null);
 	}
 


### PR DESCRIPTION
Do not call setOpen(value,callback) if value is the same than the one already set