### PR TITLE
Bug 488122 - Title text properties (like, color) problems

### DIFF
--- a/widgets/visualization/org.eclipse.nebula.visualization.xygraph/src/org/eclipse/nebula/visualization/internal/xygraph/toolbar/AnnotationConfigPage.java
+++ b/widgets/visualization/org.eclipse.nebula.visualization.xygraph/src/org/eclipse/nebula/visualization/internal/xygraph/toolbar/AnnotationConfigPage.java
@@ -163,6 +163,7 @@ public class AnnotationConfigPage {
 			@Override
 			public void widgetSelected(SelectionEvent e) {
 				FontDialog fontDialog = new FontDialog(composite.getShell());
+				fontDialog.setEffectsVisible(false);
 				if (font != null)
 					fontDialog.setFontList(font.getFontData());
 				FontData fontData = fontDialog.open();

--- a/widgets/visualization/org.eclipse.nebula.visualization.xygraph/src/org/eclipse/nebula/visualization/internal/xygraph/toolbar/AxisConfigPage.java
+++ b/widgets/visualization/org.eclipse.nebula.visualization.xygraph/src/org/eclipse/nebula/visualization/internal/xygraph/toolbar/AxisConfigPage.java
@@ -127,6 +127,7 @@ public class AxisConfigPage {
 			@Override
 			public void widgetSelected(SelectionEvent e) {
 				FontDialog fontDialog = new FontDialog(composite.getShell());
+				fontDialog.setEffectsVisible(false);
 				if (titleFont != null)
 					fontDialog.setFontList(titleFont.getFontData());
 				FontData fontData = fontDialog.open();
@@ -151,6 +152,7 @@ public class AxisConfigPage {
 			@Override
 			public void widgetSelected(SelectionEvent e) {
 				FontDialog fontDialog = new FontDialog(composite.getShell());
+				fontDialog.setEffectsVisible(false);
 				if (scaleFont != null)
 					fontDialog.setFontList(scaleFont.getFontData());
 				FontData fontData = fontDialog.open();

--- a/widgets/visualization/org.eclipse.nebula.visualization.xygraph/src/org/eclipse/nebula/visualization/internal/xygraph/toolbar/GraphConfigPage.java
+++ b/widgets/visualization/org.eclipse.nebula.visualization.xygraph/src/org/eclipse/nebula/visualization/internal/xygraph/toolbar/GraphConfigPage.java
@@ -85,6 +85,7 @@ public class GraphConfigPage {
 			@Override
 			public void widgetSelected(SelectionEvent e) {
 				FontDialog fontDialog = new FontDialog(composite.getShell());
+				fontDialog.setEffectsVisible(false);
 				if (titleFont != null)
 					fontDialog.setFontList(titleFont.getFontData());
 				FontData fontData = fontDialog.open();


### PR DESCRIPTION
On windows and MacOS, the "font selection dialog" allows users to change the text color or to specify special styles (like stroke effect).
The problem is that SWT can not handle these parameters, so users are puzzled because their selection is lot.

This fix hides the "effect" panel on the font selection dialog box.