### PR TITLE
Bug 548149 - Allow min/max date to show the allowed range

### DIFF
--- a/releng/org.eclipse.nebula.updatesite/category.xml
+++ b/releng/org.eclipse.nebula.updatesite/category.xml
@@ -51,9 +51,6 @@
    <feature url="features/org.eclipse.nebula.cwt.feature_1.1.0.qualifier.jar" id="org.eclipse.nebula.cwt.feature" version="1.1.0.qualifier">
       <category name="Nebula Release Individual Widgets"/>
    </feature>
-   <feature url="features/org.eclipse.nebula.widgets.cdatetime.feature_1.3.0.qualifier.jar" id="org.eclipse.nebula.widgets.cdatetime.feature" version="1.3.0.qualifier">
-      <category name="Nebula Release Individual Widgets"/>
-   </feature>
    <feature url="features/org.eclipse.nebula.widgets.opal.breadcrumb.feature_1.0.0.qualifier.jar" id="org.eclipse.nebula.widgets.opal.breadcrumb.feature" version="1.0.0.qualifier">
       <category name="Nebula Release Individual Widgets"/>
    </feature>
@@ -143,6 +140,9 @@
    </feature>
    <feature url="features/org.eclipse.nebula.feature_2.1.0.qualifier.jar" id="org.eclipse.nebula.feature" version="2.1.0.qualifier">
       <category name="Nebula Release all Widgets and Examples"/>
+   </feature>
+   <feature url="features/org.eclipse.nebula.widgets.cdatetime.feature_1.4.0.qualifier.jar" id="org.eclipse.nebula.widgets.cdatetime.feature" version="1.4.0.qualifier">
+      <category name="Nebula Release Individual Widgets"/>
    </feature>
    <bundle id="org.eclipse.nebula.widgets.tablecombo" version="1.2.0.qualifier">
       <category name="Nebula Release Individual Widgets"/>

--- a/widgets/cdatetime/org.eclipse.nebula.jface.cdatetime/pom.xml
+++ b/widgets/cdatetime/org.eclipse.nebula.jface.cdatetime/pom.xml
@@ -20,7 +20,7 @@ Contributors:
 	<parent>
 		<groupId>org.eclipse.nebula</groupId>
 		<artifactId>cdatetime</artifactId>
-		<version>1.3.0-SNAPSHOT</version>
+		<version>1.4.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.nebula.jface.cdatetime</artifactId>

--- a/widgets/cdatetime/org.eclipse.nebula.widgets.cdatetime.example/pom.xml
+++ b/widgets/cdatetime/org.eclipse.nebula.widgets.cdatetime.example/pom.xml
@@ -20,7 +20,7 @@ Contributors:
 	<parent>
 		<groupId>org.eclipse.nebula</groupId>
 		<artifactId>cdatetime</artifactId>
-		<version>1.3.0-SNAPSHOT</version>
+		<version>1.4.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.cdatetime.example</artifactId>

--- a/widgets/cdatetime/org.eclipse.nebula.widgets.cdatetime.feature/feature.xml
+++ b/widgets/cdatetime/org.eclipse.nebula.widgets.cdatetime.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.nebula.widgets.cdatetime.feature"
       label="Nebula CDateTime Widget"
-      version="1.3.0.qualifier"
+      version="1.4.0.qualifier"
       provider-name="Eclipse Nebula">
 
    <description url="http://www.eclipse.org/nebula/widgets/cdatetime">

--- a/widgets/cdatetime/org.eclipse.nebula.widgets.cdatetime.feature/pom.xml
+++ b/widgets/cdatetime/org.eclipse.nebula.widgets.cdatetime.feature/pom.xml
@@ -20,7 +20,7 @@ Contributors:
 	<parent>
 		<groupId>org.eclipse.nebula</groupId>
 		<artifactId>cdatetime</artifactId>
-		<version>1.3.0-SNAPSHOT</version>
+		<version>1.4.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.cdatetime.feature</artifactId>

--- a/widgets/cdatetime/org.eclipse.nebula.widgets.cdatetime.snippets/pom.xml
+++ b/widgets/cdatetime/org.eclipse.nebula.widgets.cdatetime.snippets/pom.xml
@@ -20,7 +20,7 @@ Contributors:
 	<parent>
 		<groupId>org.eclipse.nebula</groupId>
 		<artifactId>cdatetime</artifactId>
-		<version>1.3.0-SNAPSHOT</version>
+		<version>1.4.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.cdatetime.snippets</artifactId>

--- a/widgets/cdatetime/org.eclipse.nebula.widgets.cdatetime.snippets/src/org/eclipse/nebula/widgets/cdatetime/snippets/CDTSnippet11.java
+++ b/widgets/cdatetime/org.eclipse.nebula.widgets.cdatetime.snippets/src/org/eclipse/nebula/widgets/cdatetime/snippets/CDTSnippet11.java
@@ -1,0 +1,73 @@
+/****************************************************************************
+ * Copyright (c) 2008, 2019 Jeremy Dowdall
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Jeremy Dowdall <jeremyd@aspencloud.com> - initial API and implementation
+ *    Stefan Nöbauer - Bug 548149
+ *****************************************************************************/
+
+package org.eclipse.nebula.widgets.cdatetime.snippets;
+
+import java.util.Calendar;
+
+import org.eclipse.nebula.widgets.cdatetime.CDT;
+import org.eclipse.nebula.widgets.cdatetime.CDateTime;
+import org.eclipse.nebula.widgets.cdatetime.CDateTimeBuilder;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.graphics.Rectangle;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+
+
+
+public class CDTSnippet11 {
+
+	/**
+	 * @param args
+	 */
+	public static void main(String[] args) {
+		final Display display = new Display();
+		final Shell shell = new Shell(display);
+		shell.setText("CDateTime");
+		shell.setLayout(new GridLayout());
+
+		CDateTimeBuilder builder = CDateTimeBuilder.getStandard();
+		builder.setMinDate(Calendar.getInstance());
+		
+		Calendar max = Calendar.getInstance();
+		max.add(Calendar.DAY_OF_MONTH, 5);
+		builder.setMaxDate(max);
+
+		final CDateTime cdt1 = new CDateTime(shell, CDT.BORDER | CDT.DROP_DOWN);
+		cdt1.setBuilder(builder);
+		cdt1.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false));
+
+		
+		final CDateTime cdt2 = new CDateTime(shell, CDT.BORDER | CDT.SIMPLE);
+		cdt2.setBuilder(builder);
+		cdt2.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false));
+		
+		shell.pack();
+		Point size = shell.getSize();
+		Rectangle screen = display.getMonitors()[0].getBounds();
+		shell.setBounds(
+				(screen.width-size.x)/2,
+				(screen.height-size.y)/2,
+				size.x,
+				size.y
+		);
+		shell.open();
+		while (!shell.isDisposed()) {
+			if (!display.readAndDispatch())
+				display.sleep();
+		}
+		display.dispose();
+	}
+}

--- a/widgets/cdatetime/org.eclipse.nebula.widgets.cdatetime.tests/pom.xml
+++ b/widgets/cdatetime/org.eclipse.nebula.widgets.cdatetime.tests/pom.xml
@@ -20,7 +20,7 @@ Contributors:
 	<parent>
 		<groupId>org.eclipse.nebula</groupId>
 		<artifactId>cdatetime</artifactId>
-		<version>1.3.0-SNAPSHOT</version>
+		<version>1.4.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.cdatetime.tests</artifactId>

--- a/widgets/cdatetime/org.eclipse.nebula.widgets.cdatetime/META-INF/MANIFEST.MF
+++ b/widgets/cdatetime/org.eclipse.nebula.widgets.cdatetime/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.nebula.widgets.cdatetime
-Bundle-Version: 1.3.0.qualifier
+Bundle-Version: 1.4.0.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/widgets/cdatetime/org.eclipse.nebula.widgets.cdatetime/pom.xml
+++ b/widgets/cdatetime/org.eclipse.nebula.widgets.cdatetime/pom.xml
@@ -20,7 +20,7 @@ Contributors:
 	<parent>
 		<groupId>org.eclipse.nebula</groupId>
 		<artifactId>cdatetime</artifactId>
-		<version>1.3.0-SNAPSHOT</version>
+		<version>1.4.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.cdatetime</artifactId>

--- a/widgets/cdatetime/org.eclipse.nebula.widgets.cdatetime/src/org/eclipse/nebula/widgets/cdatetime/CDateTimeBuilder.java
+++ b/widgets/cdatetime/org.eclipse.nebula.widgets.cdatetime/src/org/eclipse/nebula/widgets/cdatetime/CDateTimeBuilder.java
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright (c) 2008 Jeremy Dowdall
+ * Copyright (c) 2008 - 2019 Jeremy Dowdall
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,11 +7,13 @@
  *
  * Contributors:
  *    Jeremy Dowdall <jeremyd@aspencloud.com> - initial API and implementation
+ *    Stefan Nöbauer - https://bugs.eclipse.org/bugs/show_bug.cgi?id=548149
  *****************************************************************************/
 
 package org.eclipse.nebula.widgets.cdatetime;
 
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.List;
 
 import org.eclipse.swt.SWT;
@@ -63,6 +65,9 @@ public class CDateTimeBuilder {
 
 	private int footerAlignment;
 	private boolean footerEqualColumns;
+	
+	private Calendar minDate;
+	private Calendar maxDate;
 
 	public List<Body> getBodies() {
 		return activeBodies;
@@ -131,6 +136,26 @@ public class CDateTimeBuilder {
 		return false;
 	}
 
+	/**
+	 * @return Returns a clone of the minDate or <code>null</code>.
+	 */
+	public Calendar getMinDate() {
+		if(minDate == null) {
+			return null;
+		}
+		return (Calendar) minDate.clone();
+	}
+	
+	/**
+	 * @return Returns a clone of the maxDate or <code>null</code>.
+	 */
+	public Calendar getMaxDate() {
+		if(maxDate == null) {
+			return null;
+		}
+		return  (Calendar) maxDate.clone();
+	}
+	
 	public void setBody(Body... attrs) {
 		this.bodies = attrs;
 	}
@@ -225,5 +250,30 @@ public class CDateTimeBuilder {
 		headerEqualColumns = equalColumns;
 		this.headers = attrs;
 	}
-
+	
+	/**
+	 * Sets a minimum date for the date picker. This date is exclusive.
+	 * 
+	 * @param minDate minimum date or <code>null</code> for no limit.
+	 * @return CDateTimeBuilder instance
+	 * 
+	 * @since 1.4.0
+	 */
+	public CDateTimeBuilder setMinDate(Calendar minDate) {
+		this.minDate = minDate;
+		return this;
+	}
+	
+	/**
+	 * Sets a maximum date for the date picker. This date is inclusive.
+	 * 
+	 * @param maxDate maximum date or <code>null</code> for no limit.
+	 * @return CDateTimeBuilder instance
+	 * 
+	 * @since 1.4.0
+	 */
+	public CDateTimeBuilder setMaxDate(Calendar maxDate) {
+		this.maxDate = maxDate;
+		return this;
+	}
 }

--- a/widgets/cdatetime/pom.xml
+++ b/widgets/cdatetime/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 
 	<artifactId>cdatetime</artifactId>
-	<version>1.3.0-SNAPSHOT</version>
+	<version>1.4.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<modules>


### PR DESCRIPTION
in the Calendar and to limit wrong selection

This new feature allowes to set min and max date to avoid selecting invalide date.
handled min max in:
- text entry - only valid dates can be entered in the text field. If date is invalid and no previous date is selected the Datepicker will be opend.
- date picker - invalid dates are set to enabled=false, today button makes date visible if today is not valid.

Signed-off-by: Stefan Nöbauer <stefan.noebauer@kgu-consulting.com>