### PR TITLE
include sortForward in copy() of columns

### DIFF
--- a/widgets/xviewer/org.eclipse.nebula.widgets.xviewer.core/src/org/eclipse/nebula/widgets/xviewer/core/model/XViewerColumn.java
+++ b/widgets/xviewer/org.eclipse.nebula.widgets.xviewer.core/src/org/eclipse/nebula/widgets/xviewer/core/model/XViewerColumn.java
@@ -78,6 +78,7 @@ public class XViewerColumn {
       toXCol.setMultiColumnEditable(fromXCol.multiColumnEditable);
       toXCol.setName(fromXCol.name);
       toXCol.setSortDataType(fromXCol.sortDataType);
+      toXCol.setSortForward(isSortForward());
       toXCol.setToolTip(fromXCol.toolTip);
       toXCol.setWidth(fromXCol.width);
       toXCol.setShow(fromXCol.show);
@@ -380,7 +381,7 @@ public class XViewerColumn {
 
    @Override
    public String toString() {
-      return "XViewerColumn [id=" + id + ", name=" + name + ", sortDataType=" + sortDataType + ", show=" + show + ", width=" + width + "]";
+      return "XViewerColumn [id=" + id + ", name=" + name + ", sortDataType=" + sortDataType + ", sortForward=" + isSortForward() + ", show=" + show + ", width=" + width + "]";
    }
 
    /**

--- a/widgets/xviewer/org.eclipse.nebula.widgets.xviewer/src/org/eclipse/nebula/widgets/xviewer/XViewerValueColumn.java
+++ b/widgets/xviewer/org.eclipse.nebula.widgets.xviewer/src/org/eclipse/nebula/widgets/xviewer/XViewerValueColumn.java
@@ -39,8 +39,10 @@ public class XViewerValueColumn extends XViewerColumn implements IXViewerValueCo
     */
    @Override
    public XViewerValueColumn copy() {
-      return new XViewerValueColumn(getId(), getName(), getWidth(), getAlign(), isShow(), getSortDataType(),
+      XViewerValueColumn copyColumn = new XViewerValueColumn(getId(), getName(), getWidth(), getAlign(), isShow(), getSortDataType(),
          isMultiColumnEditable(), getDescription());
+      copyColumn.setSortForward(isSortForward());
+      return copyColumn;
    }
 
    public XViewerValueColumn(String id, String name, int width, XViewerAlign align, boolean show, SortDataType sortDataType, boolean multiColumnEditable, String description) {

--- a/widgets/xviewer/org.eclipse.nebula.widgets.xviewer/src/org/eclipse/nebula/widgets/xviewer/edit/ExtendedViewerColumn.java
+++ b/widgets/xviewer/org.eclipse.nebula.widgets.xviewer/src/org/eclipse/nebula/widgets/xviewer/edit/ExtendedViewerColumn.java
@@ -34,13 +34,14 @@ public class ExtendedViewerColumn extends XViewerColumn implements IExtendedView
    }
 
    /**
-    * @see org.eclipse.nebula.widgets.xviewer.XViewerColumn#copy()
+    * @see org.eclipse.nebula.widgets.xviewer.core.model.XViewerColumn#copy()
     */
    @Override
    public XViewerColumn copy() {
-      XViewerColumn copyColumn = new ExtendedViewerColumn(super.id, super.name, super.getWidth(), super.getAlign(),
+      ExtendedViewerColumn copyColumn = new ExtendedViewerColumn(super.id, super.name, super.getWidth(), super.getAlign(),
          super.isShow(), super.getSortDataType(), super.isMultiColumnEditable(), super.getDescription());
-      ((ExtendedViewerColumn) copyColumn).setCellEditDescriptorMap(map);
+      copyColumn.setCellEditDescriptorMap(map);
+      copyColumn.setSortForward(isSortForward());
       return copyColumn;
    }
 


### PR DESCRIPTION
include field sortForward when copying XViewerColumns to keep initial descending sort order.