### PR TITLE
Bug 460622 - Nebula snapshot repositories don't work

### DIFF
--- a/releng/org.eclipse.nebula.examples.incubation.feature/feature.xml
+++ b/releng/org.eclipse.nebula.examples.incubation.feature/feature.xml
@@ -18,8 +18,8 @@
    </license>
 
    <url>
-      <discovery label="Nebula Release" url="http://download.eclipse.org/technology/nebula/snapshot"/>
-      <discovery label="Nebula Incubation" url="http://download.eclipse.org/technology/nebula/incubation/snapshot"/>
+      <discovery label="Nebula Release" url="http://download.eclipse.org/nebula/snapshot"/>
+      <discovery label="Nebula Incubation" url="http://download.eclipse.org/nebula/incubation/snapshot"/>
    </url>
 
    <requires>

--- a/releng/org.eclipse.nebula.examples.release.feature/feature.xml
+++ b/releng/org.eclipse.nebula.examples.release.feature/feature.xml
@@ -18,8 +18,8 @@
    </license>
 
    <url>
-      <discovery label="Nebula Release" url="http://download.eclipse.org/technology/nebula/snapshot"/>
-      <discovery label="Nebula Incubation" url="http://download.eclipse.org/technology/nebula/incubation/snapshot"/>
+      <discovery label="Nebula Release" url="http://download.eclipse.org/nebula/snapshot"/>
+      <discovery label="Nebula Incubation" url="http://download.eclipse.org/nebula/incubation/snapshot"/>
    </url>
 
    <requires>

--- a/releng/org.eclipse.nebula.feature/feature.xml
+++ b/releng/org.eclipse.nebula.feature/feature.xml
@@ -14,7 +14,7 @@
    </license>
 
    <url>
-      <discovery label="Nebula Incubation" url="http://download.eclipse.org/technology/nebula/incubation/snapshot"/>
+      <discovery label="Nebula Incubation" url="http://download.eclipse.org/nebula/incubation/snapshot"/>
    </url>
 
    <includes

--- a/releng/org.eclipse.nebula.incubation.feature/feature.xml
+++ b/releng/org.eclipse.nebula.incubation.feature/feature.xml
@@ -18,7 +18,7 @@
    </license>
 
    <url>
-      <discovery label="Nebula Release" url="http://download.eclipse.org/technology/nebula/snapshot"/>
+      <discovery label="Nebula Release" url="http://download.eclipse.org/nebula/snapshot"/>
    </url>
 
    <includes

--- a/releng/org.eclipse.nebula.nebula-incubation/pom.xml
+++ b/releng/org.eclipse.nebula.nebula-incubation/pom.xml
@@ -23,7 +23,7 @@ Contributors:
 	<description>Parent pom for all incubation widgets in Nebula</description>
 
 	<properties>
-		<download-publish-path>/home/data/httpd/download.eclipse.org/technology/nebula/incubation/snapshot</download-publish-path>
+		<download-publish-path>/home/data/httpd/download.eclipse.org/nebula/incubation/snapshot</download-publish-path>
 	</properties>
 
 	<parent>

--- a/releng/org.eclipse.nebula.nebula-release/pom.xml
+++ b/releng/org.eclipse.nebula.nebula-release/pom.xml
@@ -15,7 +15,7 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<download-publish-path>/home/data/httpd/download.eclipse.org/technology/nebula/snapshot</download-publish-path>
+		<download-publish-path>/home/data/httpd/download.eclipse.org/nebula/snapshot</download-publish-path>
 	</properties>
 
 	<modules>


### PR DESCRIPTION
Removed occurrences of old repository locations in Nebula.