### PR TITLE
Bug 550104 - Text Selection in not editable CDateTime Widget should be as simple text selection

### DIFF
--- a/widgets/cdatetime/org.eclipse.nebula.widgets.cdatetime.snippets/src/org/eclipse/nebula/widgets/cdatetime/snippets/CDTSnippet11.java
+++ b/widgets/cdatetime/org.eclipse.nebula.widgets.cdatetime.snippets/src/org/eclipse/nebula/widgets/cdatetime/snippets/CDTSnippet11.java
@@ -13,6 +13,7 @@
 package org.eclipse.nebula.widgets.cdatetime.snippets;
 
 import java.util.Calendar;
+import java.util.Date;
 
 import org.eclipse.nebula.widgets.cdatetime.CDT;
 import org.eclipse.nebula.widgets.cdatetime.CDateTime;
@@ -47,12 +48,19 @@ public class CDTSnippet11 {
 
 		final CDateTime cdt1 = new CDateTime(shell, CDT.BORDER | CDT.DROP_DOWN);
 		cdt1.setBuilder(builder);
+		cdt1.setSelection(new Date());
 		cdt1.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false));
-
 		
-		final CDateTime cdt2 = new CDateTime(shell, CDT.BORDER | CDT.SIMPLE);
+		final CDateTime cdt2 = new CDateTime(shell, CDT.BORDER | CDT.DROP_DOWN);
 		cdt2.setBuilder(builder);
 		cdt2.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false));
+		cdt2.setSelection(new Date());
+		cdt2.setEditable(false);
+		
+		final CDateTime cdt3 = new CDateTime(shell, CDT.BORDER | CDT.SIMPLE);
+		cdt3.setBuilder(builder);
+		cdt3.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false));
+		cdt3.setEditable(false);
 		
 		shell.pack();
 		Point size = shell.getSize();

--- a/widgets/cdatetime/org.eclipse.nebula.widgets.cdatetime/src/org/eclipse/nebula/widgets/cdatetime/CDateTime.java
+++ b/widgets/cdatetime/org.eclipse.nebula.widgets.cdatetime/src/org/eclipse/nebula/widgets/cdatetime/CDateTime.java
@@ -2065,7 +2065,9 @@ public class CDateTime extends BaseCombo {
 					text.setText(string);
 					text.getControl().addListener(SWT.Verify, textListener);
 				}
-				text.getControl().setSelection(selStart, selEnd);
+				if((text.getControl().getStyle() & SWT.READ_ONLY) == 0) {
+					text.getControl().setSelection(selStart, selEnd);
+				}
 			}
 		};
 


### PR DESCRIPTION
If the CDateTime widget is not editable it should be possible to select the entire date value by double clicking like in normal text widget.

Signed-off-by: Stefan Nöbauer <stefan.noebauer@kgu-consulting.com>