### PR TITLE
Bug 550437: Fix Layouting issues on dialog for Exception and input

### DIFF
--- a/widgets/opal/commons/org.eclipse.nebula.widgets.opal.commons/src/org/eclipse/nebula/widgets/opal/commons/SWTGraphicUtil.java
+++ b/widgets/opal/commons/org.eclipse.nebula.widgets.opal.commons/src/org/eclipse/nebula/widgets/opal/commons/SWTGraphicUtil.java
@@ -1,11 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2011 Laurent CARON All rights reserved. This program and the
+ * Copyright (c) 2011-2019 Laurent CARON All rights reserved. This program and the
  * accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
- * Contributors: Laurent CARON (laurent.caron at gmail dot com) - Initial
- * implementation and API
+ * Contributors: 
+ * 	Laurent CARON (laurent.caron at gmail dot com) - Initial implementation and API
+ * 	Stefan Nöbauer - Bug 550437 
  *******************************************************************************/
 package org.eclipse.nebula.widgets.opal.commons;
 
@@ -271,15 +272,12 @@ public class SWTGraphicUtil {
 	 * @return the bounds of the monitor on which the shell is running
 	 */
 	public static Rectangle getBoundsOfMonitorOnWhichShellIsDisplayed(final Shell shell) {
-		for (final Monitor monitor : shell.getDisplay().getMonitors()) {
-			final Rectangle monitorBounds = monitor.getBounds();
-			final Rectangle shellBounds = shell.getBounds();
-			if (monitorBounds.contains(shellBounds.x, shellBounds.y)) {
-				return monitorBounds;
-			}
-		}
-		final Monitor primary = shell.getDisplay().getPrimaryMonitor();
-		return primary.getBounds();
+		Monitor monitor = shell.getDisplay().getPrimaryMonitor();
+		if(shell != null && shell.getMonitor() != null) {
+			monitor = shell.getMonitor();
+		} 
+		
+		return monitor.getBounds();
 	}
 
 	/**

--- a/widgets/opal/dialog/org.eclipse.nebula.widgets.opal.dialog.snippets/src/org/eclipse/nebula/widgets/opal/dialog/snippets/OpalDialogSnippet.java
+++ b/widgets/opal/dialog/org.eclipse.nebula.widgets.opal.dialog.snippets/src/org/eclipse/nebula/widgets/opal/dialog/snippets/OpalDialogSnippet.java
@@ -1,12 +1,13 @@
 /*******************************************************************************
- * Copyright (c) 2011 Laurent CARON All rights reserved. This program and the
+ * Copyright (c) 2011-2019 Laurent CARON All rights reserved. This program and the
  * accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
- * Contributors: Laurent CARON (laurent.caron at gmail dot com) - initial API
- * and implementation Eugene Ryzhikov - Author of the Oxbow Project
- * (http://code.google.com/p/oxbow/) - Inspiration
+ * Contributors: 
+ * 	Laurent CARON (laurent.caron at gmail dot com) - initial API and implementation 
+ *  Eugene Ryzhikov - Author of the Oxbow Project (http://code.google.com/p/oxbow/) - Inspiration
+ *  Stefan Nöbauer - Bug 550437 
  *******************************************************************************/
 package org.eclipse.nebula.widgets.opal.dialog.snippets;
 
@@ -141,7 +142,7 @@ public class OpalDialogSnippet {
 		button14.setText("Issue 29");
 		button14.setLayoutData(new GridData(GridData.FILL, GridData.FILL, false, false));
 		button14.addListener(SWT.Selection, e -> {
-			testIssue29();
+			testIssue29(shell);
 		});
 
 		final Button button15 = new Button(shell, SWT.PUSH);
@@ -180,7 +181,7 @@ public class OpalDialogSnippet {
 	}
 
 	private static void displayCrashAndBurn() {
-		Dialog.error("CRASH AND BURN !", "The application has performed an illegal action. This action has been logged and reported.");
+		Dialog.error("CRASH AND BURN !", "The application has performed an illegal action. This action has been logged and reported. This text may also a bit longer as expected");
 	}
 
 	private static void displayYouWon() {
@@ -266,7 +267,7 @@ public class OpalDialogSnippet {
 	}
 
 	private static void displayInput() {
-		final String input = Dialog.ask("Enter you name", "or any other text if you prefer", "Laurent CARON");
+		final String input = Dialog.ask("Enter you name", "or any other text if you prefer Somthing longer may stress the layout", "Laurent CARON");
 		System.out.println("Choice is..." + input);
 	}
 
@@ -306,8 +307,8 @@ public class OpalDialogSnippet {
 		dialog.show();
 	}
 
-	private static void testIssue29() {
-		final Dialog d = new Dialog();
+	private static void testIssue29(Shell parent) {
+		final Dialog d = new Dialog(parent);
 		d.setCenterPolicy(Dialog.CenterOption.CENTER_ON_DIALOG);
 		d.setTitle("foo title");
 

--- a/widgets/opal/dialog/org.eclipse.nebula.widgets.opal.dialog/src/org/eclipse/nebula/widgets/opal/dialog/DialogArea.java
+++ b/widgets/opal/dialog/org.eclipse.nebula.widgets.opal.dialog/src/org/eclipse/nebula/widgets/opal/dialog/DialogArea.java
@@ -1,11 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2011 Laurent CARON All rights reserved. This program and the
+ * Copyright (c) 2011-2019 Laurent CARON All rights reserved. This program and the
  * accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
- * Contributors: Laurent CARON (laurent.caron at gmail dot com) - Initial
- * implementation and API
+ * Contributors: 
+ * 	Laurent CARON (laurent.caron at gmail dot com) - Initial implementation and API
+ * 	Stefan Nöbauer - Bug 550437 
  *******************************************************************************/
 package org.eclipse.nebula.widgets.opal.dialog;
 
@@ -26,7 +27,7 @@ abstract class DialogArea {
 	private static final String MAC_OS_DEFAULT_FONT = "Lucida Grande";
 	protected final Dialog parent;
 	private boolean initialised;
-
+	
 	/**
 	 * Constructor
 	 *
@@ -136,5 +137,4 @@ abstract class DialogArea {
 		SWTGraphicUtil.addDisposer(parent.shell, image);
 		return image;
 	}
-
 }

--- a/widgets/opal/dialog/org.eclipse.nebula.widgets.opal.dialog/src/org/eclipse/nebula/widgets/opal/dialog/MessageArea.java
+++ b/widgets/opal/dialog/org.eclipse.nebula.widgets.opal.dialog/src/org/eclipse/nebula/widgets/opal/dialog/MessageArea.java
@@ -1,11 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2011 Laurent CARON All rights reserved. This program and the
+ * Copyright (c) 2011-2019 Laurent CARON All rights reserved. This program and the
  * accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
- * Contributors: Laurent CARON (laurent.caron at gmail dot com) - Initial
- * implementation
+ * Contributors: 
+ * 	Laurent CARON (laurent.caron at gmail dot com) - Initial implementation
+ *  Stefan Nöbauer - Bug 550437 
  *******************************************************************************/
 package org.eclipse.nebula.widgets.opal.dialog;
 
@@ -17,6 +18,7 @@ import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
@@ -32,8 +34,6 @@ import org.eclipse.swt.widgets.Text;
  * Instances of this class are message areas
  */
 public class MessageArea extends DialogArea {
-	private static final int DEFAULT_MIN_HEIGHT_FOR_EXCEPTIONS = 300;
-
 	private static final int INDENT_NO_ICON = 8;
 	private static final int DEFAULT_MARGIN = 10;
 
@@ -267,10 +267,11 @@ public class MessageArea extends DialogArea {
 	private void createText(final boolean hasIcon, final boolean hasTitle) {
 		label = new ReadOnlyStyledText(composite, SWT.NONE | (verticalScrollbar ? SWT.V_SCROLL : SWT.NONE));
 		label.setText(text);
+		
 		SWTGraphicUtil.applyHTMLFormating(label);
 		label.setEditable(false);
 		label.setBackground(Display.getCurrent().getSystemColor(SWT.COLOR_WHITE));
-		final GridData gd = new GridData(GridData.FILL, GridData.FILL, true, true, 1, 1);
+		final GridData gd = new GridData(GridData.FILL, GridData.FILL, true, false, 1, 1);
 		if (height != -1) {
 			gd.heightHint = height;
 		}
@@ -320,7 +321,6 @@ public class MessageArea extends DialogArea {
 		textException.setText(StringUtil.stackStraceAsString(exception));
 		textException.setBackground(Display.getCurrent().getSystemColor(SWT.COLOR_WHITE));
 		final GridData gd = new GridData(GridData.FILL, GridData.FILL, true, true, 1, 1);
-		gd.minimumHeight = DEFAULT_MIN_HEIGHT_FOR_EXCEPTIONS;
 		textException.setLayoutData(gd);
 	}
 
@@ -402,15 +402,29 @@ public class MessageArea extends DialogArea {
 	 * Hide the exception panel
 	 */
 	void hideException() {
-		textException.dispose();
+		Point size = parent.shell.getSize();
+		
+		textException.setVisible(false);
+		((GridData)textException.getLayoutData()).exclude = true;
+		
+		parent.shell.setMinimumSize(new Point(0,0));
+		parent.shell.layout();
 		parent.pack();
+		parent.shell.setMinimumSize(parent.shell.getSize());
+		parent.setLastSize(size);
 	}
 
 	/**
 	 * Show the exception panel
 	 */
 	void showException() {
-		createTextException();
+		if(textException == null) {
+			createTextException();
+		} else {
+			textException.setVisible(true);
+			((GridData)textException.getLayoutData()).exclude = false;
+			parent.shell.layout();
+		}
 		parent.pack();
 	}
 


### PR DESCRIPTION
I fixed some Layouting issues:
- Center shell fixed for multi monitor
- CENTER_ON_DIALOG test fixed (add the parent shell)
- fixed Layout on dialog with input field
- fixed jumping layouting on exception dialog when opening/closing details
- added minsize

Signed-off-by: Stefan Nöbauer <stefan.noebauer@kgu-consulting.com>