### PR TITLE
Bug 506601 - GaugeFigure lacks title and unit of value

### DIFF
--- a/examples/org.eclipse.nebula.snippets/src/org/eclipse/nebula/snippets/visualization/GaugeExample.java
+++ b/examples/org.eclipse.nebula.snippets/src/org/eclipse/nebula/snippets/visualization/GaugeExample.java
@@ -43,12 +43,14 @@ public class GaugeExample {
 		gaugeFigure.setForegroundColor(
 				XYGraphMediaFactory.getInstance().getColor(255, 255, 255));
 		
-		gaugeFigure.setRange(-100, 100);
+		gaugeFigure.setRange(-90, 90);
 		gaugeFigure.setLoLevel(-50);
 		gaugeFigure.setLoloLevel(-80);
 		gaugeFigure.setHiLevel(60);
 		gaugeFigure.setHihiLevel(80);
 		gaugeFigure.setMajorTickMarkStepHint(50);
+		gaugeFigure.setTitle("Rotation");
+		gaugeFigure.setUnit("Degrees");
 		
 		lws.setContents(gaugeFigure);		
 		
@@ -59,7 +61,7 @@ public class GaugeExample {
 			public void run() {
 				Display.getDefault().asyncExec(new Runnable() {					
 					public void run() {
-						gaugeFigure.setValue(Math.sin(counter++/10.0)*100);						
+						gaugeFigure.setValue(Math.sin(counter++/10.0)*90);						
 					}
 				});
 			}

--- a/widgets/visualization/org.eclipse.nebula.visualization.widgets/src/org/eclipse/nebula/visualization/widgets/figures/GaugeFigure.java
+++ b/widgets/visualization/org.eclipse.nebula.visualization.widgets/src/org/eclipse/nebula/visualization/widgets/figures/GaugeFigure.java
@@ -63,6 +63,12 @@ public class GaugeFigure extends AbstractRoundRampedFigure {
 	private Label valueLabel;
 	private Boolean support3D;
 	
+	private Label unitLabel;
+	private String unit;
+	
+	private Label titleLabel;
+	private String title;
+	
 	public GaugeFigure() {
 		super();
 		transparent = true;
@@ -72,6 +78,12 @@ public class GaugeFigure extends AbstractRoundRampedFigure {
 		
 		valueLabel = new Label();	
 		valueLabel.setFont(DEFAULT_LABEL_FONT);
+		
+		unitLabel = new Label();
+		unitLabel.setFont(DEFAULT_LABEL_FONT);
+		
+		titleLabel = new Label();
+		titleLabel.setFont(DEFAULT_LABEL_FONT);
 		
 		needle = new Needle();
 		needle.setFill(true);
@@ -84,6 +96,8 @@ public class GaugeFigure extends AbstractRoundRampedFigure {
 		add(ramp, GaugeLayout.RAMP);
 		add(scale, GaugeLayout.SCALE);		
 		add(valueLabel, GaugeLayout.VALUE_LABEL);
+		add(unitLabel, GaugeLayout.UNIT_LABEL);
+		add(titleLabel, GaugeLayout.TITLE_LABEL);
 		add(needle, GaugeLayout.NEEDLE);
 		add(needleCenter, GaugeLayout.NEEDLE_CENTER);		
 		addFigureListener(new FigureListener() {			
@@ -147,9 +161,6 @@ public class GaugeFigure extends AbstractRoundRampedFigure {
 			final double LR_FILL_PART = 8.5d/10d;
 			final double UP_ANGLE = 0d * Math.PI/180d;
 			final double DOWN_ANGLE = 35d * Math.PI/180d;
-			//add this to eliminate the repaint bug on Mac
-
-//			graphics.fillOval(new Rectangle());
 
 			Pattern glossyPattern = GraphicsUtil.createScaledPattern(graphics, Display.getCurrent(), 
 					area.x + area.width/2, (float)(area.y + area.height/2 - R * UD_FILL_PART),
@@ -209,6 +220,38 @@ public class GaugeFigure extends AbstractRoundRampedFigure {
 		return effect3D;
 	}
 	
+	/**
+	 * @return the displayed unit
+	 */
+	public String getUnit() {
+		return unit;
+	}
+	
+	/**
+	 * @param unit unit that will be displayed above the value label
+	 */
+	public void setUnit(String unit) {
+		this.unit = unit;
+		unitLabel.setText(unit);		
+	}
+	
+	/**
+	 * @return the title associated to this gauge
+	 */
+	public String getTitle() {
+		return title;
+	}
+	
+	/**
+	 * @param title title that will be displayed under the value label
+	 */
+	public void setTitle(String title) {
+		this.title = title;
+		titleLabel.setText(title);
+	}
+
+
+
 	class Needle extends Polygon {
 		public Needle() {
 			setBackgroundColor(DEFAULT_NEEDLE_COLOR);
@@ -232,9 +275,6 @@ public class GaugeFigure extends AbstractRoundRampedFigure {
 			if(support3D == null)
 				support3D = GraphicsUtil.testPatternSupported(graphics);
 			if(effect3D && support3D){		
-				//add this to eliminate the repaint bug on Mac
-//				graphics.fillOval(new Rectangle());
-
 					pattern = GraphicsUtil.createScaledPattern(graphics, Display.getCurrent(), bounds.x, bounds.y,
 							bounds.x + bounds.width, bounds.y + bounds.height, WHITE_COLOR, BORDER_COLOR);
 					graphics.setBackgroundPattern(pattern);							
@@ -260,12 +300,18 @@ public class GaugeFigure extends AbstractRoundRampedFigure {
 		public static final String NEEDLE_CENTER = "needleCenter";      //$NON-NLS-1$
 		/** Used as a constraint for the value label*/
 		public static final String VALUE_LABEL = "valueLabel";      //$NON-NLS-1$
+		/** Used as a constraint for the unit label*/
+		public static final String UNIT_LABEL = "unitLabel";      //$NON-NLS-1$
+		/** Used as a constraint for the title label*/
+		public static final String TITLE_LABEL = "titleLabel";      //$NON-NLS-1$
 		
 		private RoundScale scale;
 		private RoundScaledRamp ramp;
 		private Polygon needle;
 		private NeedleCenter needleCenter;
 		private Label valueLabel;
+		private Label titleLabel;
+		private Label unitLabel;
 		private PointList needlePoints = new PointList(new int[] {0,0,0,0,0,0});
 		
 		
@@ -281,6 +327,11 @@ public class GaugeFigure extends AbstractRoundRampedFigure {
 				needleCenter = (NeedleCenter) child;
 			else if (constraint.equals(VALUE_LABEL))
 				valueLabel = (Label)child;
+			else if (constraint.equals(TITLE_LABEL))
+				titleLabel = (Label)child;
+			else if (constraint.equals(UNIT_LABEL))
+				unitLabel = (Label)child;
+			
 		}
 
 
@@ -312,11 +363,27 @@ public class GaugeFigure extends AbstractRoundRampedFigure {
 				ramp.setBounds(rampBounds.shrink(area.width/4, area.height/4));
 			}
 			
+
+			
 			if(valueLabel != null) {
 				Dimension labelSize = valueLabel.getPreferredSize();
 				valueLabel.setBounds(new Rectangle(area.x + area.width/2 - labelSize.width/2,
-						area.y + area.height * 7/8 - labelSize.height/2,
+						(int)(area.y + area.height * 6.3f/8 - labelSize.height/2),
 						labelSize.width, labelSize.height));
+			}
+			
+			if(title != null) {
+				Dimension titleSize = titleLabel.getPreferredSize();
+				titleLabel.setBounds(new Rectangle(area.x + area.width/2 - titleSize.width/2,
+						(int)(area.y + area.height * 7.1f/8 - titleSize.height/2),
+						titleSize.width, titleSize.height));
+			}
+			
+			if(unit != null) {
+				Dimension unitSize = unitLabel.getPreferredSize();
+				unitLabel.setBounds(new Rectangle(area.x + area.width/2 - unitSize.width/2,
+						(int)(area.y + area.height * 5.5f/8 - unitSize.height/2),
+						unitSize.width, unitSize.height));
 			}
 			
 			if(needle != null && scale != null) {


### PR DESCRIPTION
GaugeFigure has now two properties : unit and title, so users can display the unit of displayed date, and a title.
Both properties are optionnal

The example has been updated to reflect the changes.

Please find enclosed a sample picture of the result

![image](https://user-images.githubusercontent.com/1170014/65249742-cbf1af00-daf4-11e9-895c-5da644708e71.png)
