### PR TITLE
Bug 400477 - CellHover incorrectly includes the footerHeight

### DIFF
--- a/widgets/grid/org.eclipse.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/Grid.java
+++ b/widgets/grid/org.eclipse.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/Grid.java
@@ -7441,7 +7441,7 @@ public class Grid extends Canvas {
 
 		if (col != null) {
 			if (item != null) {
-				if (y < getClientArea().height - footerHeight) {
+				if (y < getClientArea().height - (columnFootersVisible ? footerHeight : 0)) {
 					col.getCellRenderer().setBounds(item.getBounds(columns.indexOf(col)));
 
 					if (col.getCellRenderer().notify(IInternalWidget.MouseMove, new Point(x, y), item)) {


### PR DESCRIPTION
CellHover incorrectly includes the footerHeight regardless if the footer
is visible

Apply patch provided by Sean Ruff