### PR TITLE
Bug 246825 - HandleRowResizerDragging method

### DIFF
--- a/widgets/grid/org.eclipse.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/Grid.java
+++ b/widgets/grid/org.eclipse.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/Grid.java
@@ -4857,7 +4857,7 @@ public class Grid extends Canvas {
 			newHeight = getClientArea().height;
 		}
 
-		if (newHeight == rowBeingResized.getHeight()) {
+		if (rowBeingResized == null || newHeight == rowBeingResized.getHeight()) {
 			return;
 		}
 


### PR DESCRIPTION
HandleRowResizerDragging method was used when rowBeginingResized was
null