### PR TITLE
Bug 551658 - preempt Java 9 deprecations

### DIFF
--- a/widgets/visualization/org.eclipse.nebula.visualization.widgets/src/org/eclipse/nebula/visualization/widgets/figureparts/RoundScaleTickLabels.java
+++ b/widgets/visualization/org.eclipse.nebula.visualization.widgets/src/org/eclipse/nebula/visualization/widgets/figureparts/RoundScaleTickLabels.java
@@ -247,17 +247,16 @@ public class RoundScaleTickLabels extends Figure {
      * 
      * @param base
      *            the base
-     * @param expornent
+     * @param exponent
      *            the exponent
      * @return the value <tt>a<sup>b</sup></tt> in <tt>BigDecimal</tt>
      */
-    private BigDecimal pow(double base, int expornent) {
+    private BigDecimal pow(double base, int exponent) {
         BigDecimal value;
-        if (expornent > 0) {
-            value = new BigDecimal(new Double(base).toString()).pow(expornent);
+        if (exponent > 0) {
+            value = BigDecimal.valueOf(base).pow(exponent);
         } else {
-            value = BigDecimal.ONE.divide(new BigDecimal(new Double(base)
-                    .toString()).pow(-expornent));
+            value = BigDecimal.ONE.divide(BigDecimal.valueOf(base).pow(-exponent));
         }
         return value;
     }
@@ -375,8 +374,8 @@ public class RoundScaleTickLabels extends Figure {
 		int minLogDigit = (int) Math.ceil(minLog);
         int maxLogDigit = (int) Math.ceil(Math.log10(max));
 
-        final BigDecimal minDec = new BigDecimal(new Double(min).toString());
-        BigDecimal tickStep = pow(10, minLogDigit-1);        
+        final BigDecimal minDec = BigDecimal.valueOf(min);
+        BigDecimal tickStep = pow(10, minLogDigit-1);
         BigDecimal firstPosition;
 
         if (minDec.remainder(tickStep).doubleValue() <= 0) {

--- a/widgets/visualization/org.eclipse.nebula.visualization.xygraph/src/org/eclipse/nebula/visualization/xygraph/figures/Trace.java
+++ b/widgets/visualization/org.eclipse.nebula.visualization.xygraph/src/org/eclipse/nebula/visualization/xygraph/figures/Trace.java
@@ -961,16 +961,16 @@ public class Trace extends Figure implements IDataProviderListener, IAxisListene
 							if (!use_advanced_graphics && predpPos.x() == dpPos.x()) {
 								// Stores bar line infomration in memory, and
 								// draw lines later.
-								Integer posX = new Integer(predpPos.x());
+								Integer posX = Integer.valueOf(predpPos.x());
 								Integer highY;
 								Integer lowY;
 
 								if (dpPos.y() > predpPos.y()) {
-									highY = new Integer(dpPos.y());
-									lowY = new Integer(predpPos.y());
+									highY = Integer.valueOf(dpPos.y());
+									lowY = Integer.valueOf(predpPos.y());
 								} else {
-									highY = new Integer(predpPos.y());
-									lowY = new Integer(dpPos.y());
+									highY = Integer.valueOf(predpPos.y());
+									lowY = Integer.valueOf(dpPos.y());
 								}
 
 								if (bottomPoints.containsKey(posX)) {


### PR DESCRIPTION
Migrate from using Number constructors and use static methods