### PR TITLE
Bug 356936 - Move DefaultCellRenderer to a none-internal package

### DIFF
--- a/widgets/grid/org.eclipse.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/DefaultCellRenderer.java
+++ b/widgets/grid/org.eclipse.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/DefaultCellRenderer.java
@@ -14,13 +14,12 @@
  *    smcduff@hotmail.com - wordwrapping in bug 222280
  *    Claes Rosell<claes.rosell@solme.se> - rowspan in bug 272384
  *******************************************************************************/
-package org.eclipse.nebula.widgets.grid.internal;
+package org.eclipse.nebula.widgets.grid;
 
-import org.eclipse.nebula.widgets.grid.Grid;
-import org.eclipse.nebula.widgets.grid.GridCellRenderer;
-import org.eclipse.nebula.widgets.grid.GridColumn;
-import org.eclipse.nebula.widgets.grid.GridItem;
-import org.eclipse.nebula.widgets.grid.IInternalWidget;
+import org.eclipse.nebula.widgets.grid.internal.BranchRenderer;
+import org.eclipse.nebula.widgets.grid.internal.CheckBoxRenderer;
+import org.eclipse.nebula.widgets.grid.internal.TextUtils;
+import org.eclipse.nebula.widgets.grid.internal.ToggleRenderer;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.GC;

--- a/widgets/grid/org.eclipse.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/DefaultEmptyCellRenderer.java
+++ b/widgets/grid/org.eclipse.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/DefaultEmptyCellRenderer.java
@@ -11,11 +11,8 @@
  * Contributors:
  *    chris.gross@us.ibm.com - initial API and implementation
  *******************************************************************************/
-package org.eclipse.nebula.widgets.grid.internal;
+package org.eclipse.nebula.widgets.grid;
 
-import org.eclipse.nebula.widgets.grid.Grid;
-import org.eclipse.nebula.widgets.grid.GridCellRenderer;
-import org.eclipse.nebula.widgets.grid.GridItem;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.GC;

--- a/widgets/grid/org.eclipse.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/Grid.java
+++ b/widgets/grid/org.eclipse.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/Grid.java
@@ -38,7 +38,6 @@ import java.util.function.ToIntFunction;
 import org.eclipse.nebula.widgets.grid.internal.DefaultBottomLeftRenderer;
 import org.eclipse.nebula.widgets.grid.internal.DefaultColumnGroupHeaderRenderer;
 import org.eclipse.nebula.widgets.grid.internal.DefaultDropPointRenderer;
-import org.eclipse.nebula.widgets.grid.internal.DefaultEmptyCellRenderer;
 import org.eclipse.nebula.widgets.grid.internal.DefaultEmptyColumnFooterRenderer;
 import org.eclipse.nebula.widgets.grid.internal.DefaultEmptyColumnHeaderRenderer;
 import org.eclipse.nebula.widgets.grid.internal.DefaultEmptyRowHeaderRenderer;

--- a/widgets/grid/org.eclipse.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/GridColumn.java
+++ b/widgets/grid/org.eclipse.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/GridColumn.java
@@ -23,7 +23,6 @@ package org.eclipse.nebula.widgets.grid;
 
 import java.util.Locale;
 
-import org.eclipse.nebula.widgets.grid.internal.DefaultCellRenderer;
 import org.eclipse.nebula.widgets.grid.internal.DefaultColumnFooterRenderer;
 import org.eclipse.nebula.widgets.grid.internal.DefaultColumnHeaderRenderer;
 import org.eclipse.swt.SWT;


### PR DESCRIPTION
Move DefaultCellRenderer and DefaultEmptyCellRenderer out of the *internal* package