### PR TITLE
Bug 488927 - fix tick marks

### DIFF
--- a/widgets/visualization/org.eclipse.nebula.visualization.xygraph/src/org/eclipse/nebula/visualization/xygraph/linearscale/IScaleProvider.java
+++ b/widgets/visualization/org.eclipse.nebula.visualization.xygraph/src/org/eclipse/nebula/visualization/xygraph/linearscale/IScaleProvider.java
@@ -88,6 +88,11 @@ public interface IScaleProvider {
 	public void setAutoFormat(boolean autoFormat);
 
 	/**
+	 * @return format pattern string
+	 */
+	public String getFormatPattern();
+
+	/**
 	 * @return margin
 	 */
 	public int getMargin();

--- a/widgets/visualization/org.eclipse.nebula.visualization.xygraph/src/org/eclipse/nebula/visualization/xygraph/linearscale/LinearScaleTicks.java
+++ b/widgets/visualization/org.eclipse.nebula.visualization.xygraph/src/org/eclipse/nebula/visualization/xygraph/linearscale/LinearScaleTicks.java
@@ -271,8 +271,23 @@ public class LinearScaleTicks implements ITicksProvider {
 		} else {
 			gridStep = Math.pow(10, exp); // 1*10^exponent
 		}
+
+		if (exp < 0) { // ensure grid steps are printable for scale format
+			String pattern = scale.getFormatPattern();
+			if (!pattern.contains("E")) {
+				int e = pattern.lastIndexOf(".") + 1;
+				if (e > 0) {
+					double g = Math.pow(10, -(pattern.length() - e));
+					if (gridStep < g) {
+						gridStep = g;
+					}
+				}
+			}
+		}
+
 		if (minBigger)
 			gridStep = -gridStep;
+
 		return gridStep;
 	}
 
@@ -473,6 +488,11 @@ public class LinearScaleTicks implements ITicksProvider {
 
 			int tickLabelPosition = (int) ((p - min) / t * length) + scale.getMargin();
 			tickLabelPositions.add(tickLabelPosition);
+		}
+
+		if (scale.isHorizontal()) {
+			System.err.println("For length of " + length);
+			System.err.println(tickLabelValues);
 		}
 
 		// always add max

--- a/widgets/visualization/org.eclipse.nebula.visualization.xygraph/src/org/eclipse/nebula/visualization/xygraph/linearscale/LinearScaleTicks.java
+++ b/widgets/visualization/org.eclipse.nebula.visualization.xygraph/src/org/eclipse/nebula/visualization/xygraph/linearscale/LinearScaleTicks.java
@@ -490,11 +490,6 @@ public class LinearScaleTicks implements ITicksProvider {
 			tickLabelPositions.add(tickLabelPosition);
 		}
 
-		if (scale.isHorizontal()) {
-			System.err.println("For length of " + length);
-			System.err.println(tickLabelValues);
-		}
-
 		// always add max
 		max *= f;
 		tickLabelValues.add(max);


### PR DESCRIPTION
When a fixed decimal precision format is used with sufficiently long axes, the grid step can become small enough so that neighbouring labels are duplicated. Duplicated ticks are removed but limited precision may round a tick value negative zero which then does not render the next label invisible. This fix ensures grid steps are big enough for the scale format to make tick labels distinct