### PR TITLE
Fix issues #192 : Notifier examples look bad on Linux

### DIFF
--- a/widgets/opal/notifier/org.eclipse.nebula.widgets.opal.notifier/src/org/eclipse/nebula/widgets/opal/notifier/Notifier.java
+++ b/widgets/opal/notifier/org.eclipse.nebula.widgets.opal.notifier/src/org/eclipse/nebula/widgets/opal/notifier/Notifier.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors: Laurent CARON (laurent.caron at gmail dot com) - initial API
@@ -190,6 +190,8 @@ public class Notifier {
 
 		final Color textColor = colors.textColor;
 		textLabel.setForeground(textColor);
+		final Color fillColor = colors.rightColor;
+		textLabel.setBackground(fillColor);
 
 		textLabel.setText(text);
 		SWTGraphicUtil.applyHTMLFormating(textLabel);


### PR DESCRIPTION
Force the background for the "text" part