### PR TITLE
Bug 558404 - CDT.SPINNER style does not draw spinner

### DIFF
--- a/widgets/cdatetime/org.eclipse.nebula.widgets.cdatetime/src/org/eclipse/nebula/widgets/cdatetime/CDateTime.java
+++ b/widgets/cdatetime/org.eclipse.nebula.widgets.cdatetime/src/org/eclipse/nebula/widgets/cdatetime/CDateTime.java
@@ -161,6 +161,10 @@ public class CDateTime extends BaseCombo {
 			int sWidth = sRect.x + sRect.width
 					- 2 * spinner.getControl().getBorderWidth() + 1;
 
+			if (gtk && sWidth==0) {
+				sWidth = 67;
+			}			
+			
 			size.x += sWidth;
 			size.x++;
 			size.y += textMarginHeight;
@@ -191,6 +195,10 @@ public class CDateTime extends BaseCombo {
 			int sWidth = sRect.x + sRect.width
 					- 2 * spinner.getControl().getBorderWidth() + 1;
 
+			if (gtk && sWidth==0) {
+				sWidth = 67;
+			}			
+			
 			tSize.x = cRect.width - sWidth;
 
 			text.setBounds(cRect.x, cRect.y + getBorderWidth(), tSize.x,


### PR DESCRIPTION
Bug on gtx : spinner.getControl().computeTrim(0, 0, 0, 0) returns a length of 0...