### PR TITLE
Bug 560043 - Make the text widget gray when multichoice is not editable

### DIFF
--- a/widgets/opal/multichoice/org.eclipse.nebula.widgets.opal.multichoice.snippets/src/org/eclipse/nebula/widgets/opal/multichoice/snippets/MultiChoiceSnippet.java
+++ b/widgets/opal/multichoice/org.eclipse.nebula.widgets.opal.multichoice.snippets/src/org/eclipse/nebula/widgets/opal/multichoice/snippets/MultiChoiceSnippet.java
@@ -180,6 +180,16 @@ public class MultiChoiceSnippet {
 		mcNotEditable.addAll(euroZone);
 		mcNotEditable.setEditable(false);
 		addButons(mcNotEditable);
+		
+		
+		drawLabel(shell, "Not Enabled Multichoice :");
+		final MultiChoice<String> mcNotEnabled = new MultiChoice<>(shell, SWT.READ_ONLY);
+		final GridData gridDataNotEnabled = new GridData(GridData.FILL, GridData.BEGINNING, true, true);
+		gridDataNotEnabled.widthHint = 200;
+		mcNotEnabled.setLayoutData(gridDataNotEnabled);
+		mcNotEnabled.addAll(euroZone);
+		mcNotEnabled.setEditable(false);
+		addButons(mcNotEnabled);
 
 		// display the shell...
 		shell.open();

--- a/widgets/opal/multichoice/org.eclipse.nebula.widgets.opal.multichoice/src/org/eclipse/nebula/widgets/opal/multichoice/MultiChoice.java
+++ b/widgets/opal/multichoice/org.eclipse.nebula.widgets.opal.multichoice/src/org/eclipse/nebula/widgets/opal/multichoice/MultiChoice.java
@@ -1089,7 +1089,7 @@ public class MultiChoice<T> extends Composite {
 			if (this.background != null) {
 				checkBoxButton.setBackground(this.background);
 			}
-			checkBoxButton.setEnabled(text.getEditable());
+			checkBoxButton.setEnabled(text.isEnabled()); //TODO
 
 			checkBoxButton.setData(o);
 			checkBoxButton.setLayoutData(new GridData(GridData.BEGINNING, GridData.CENTER, false, false));

--- a/widgets/opal/multichoice/org.eclipse.nebula.widgets.opal.multichoice/src/org/eclipse/nebula/widgets/opal/multichoice/MultiChoice.java
+++ b/widgets/opal/multichoice/org.eclipse.nebula.widgets.opal.multichoice/src/org/eclipse/nebula/widgets/opal/multichoice/MultiChoice.java
@@ -1089,8 +1089,6 @@ public class MultiChoice<T> extends Composite {
 			if (this.background != null) {
 				checkBoxButton.setBackground(this.background);
 			}
-			checkBoxButton.setEnabled(text.isEnabled()); //TODO
-
 			checkBoxButton.setData(o);
 			checkBoxButton.setLayoutData(new GridData(GridData.BEGINNING, GridData.CENTER, false, false));
 			checkBoxButton.setText(this.labelProvider.getText(o));


### PR DESCRIPTION
When the widget is not editable, the checkbox are enabled (confusion between isEnabled and isEditable