### PR TITLE
Bug 566219 - CDateTime widget mouse wheel event when not focused

### DIFF
--- a/widgets/cdatetime/org.eclipse.nebula.widgets.cdatetime/src/org/eclipse/nebula/widgets/cdatetime/CDateTime.java
+++ b/widgets/cdatetime/org.eclipse.nebula.widgets.cdatetime/src/org/eclipse/nebula/widgets/cdatetime/CDateTime.java
@@ -312,6 +312,11 @@ public class CDateTime extends BaseCombo {
 			}
 			break;
 		case SWT.MouseWheel:
+			Control focusedControl = getDisplay().getFocusControl();
+			if (getTextWidget() != null && getTextWidget().getControl() != focusedControl) {
+				// Do not handle mousewheel events if the widget does not have focus
+				break;
+			}
 			if (event.count > 0) {
 				fieldAdjust(1);
 			} else {


### PR DESCRIPTION
Do not handle mouse wheel event if the focused control is not the text part of the CDateTimeWidget