### PR TITLE
Bug 568370 - NullPointerException in MouseMove event handler

### DIFF
--- a/widgets/opal/rangeslider/org.eclipse.nebula.widgets.opal.rangeslider/src/org/eclipse/nebula/widgets/opal/rangeslider/RangeSlider.java
+++ b/widgets/opal/rangeslider/org.eclipse.nebula.widgets.opal.rangeslider/src/org/eclipse/nebula/widgets/opal/rangeslider/RangeSlider.java
@@ -464,6 +464,9 @@ public class RangeSlider extends Canvas {
 	 * @param e
 	 */
 	private void selectKnobs(final Event e) {
+		if (coordLower == null) {
+			return;
+		}
 		final Image img = orientation == SWT.HORIZONTAL ? slider : vSlider;
 		final int x = e.x, y = e.y;
 		lowerHover = x >= coordLower.x && x <= coordLower.x + img.getBounds().width && y >= coordLower.y && y <= coordLower.y + img.getBounds().height;

--- a/widgets/opal/roundedtoolbar/org.eclipse.nebula.widgets.opal.roundedtoolbar/src/org/eclipse/nebula/widgets/opal/roundedtoolbar/RoundedToolItem.java
+++ b/widgets/opal/roundedtoolbar/org.eclipse.nebula.widgets.opal.roundedtoolbar/src/org/eclipse/nebula/widgets/opal/roundedtoolbar/RoundedToolItem.java
@@ -360,6 +360,7 @@ public class RoundedToolItem extends Item {
 		gc.fillGradientRectangle(x, 0, width + parentToolbar.getCornerRadius(), toolbarHeight, true);
 
 		gc.setClipping((Rectangle) null);
+		path.dispose();
 	}
 
 	private void drawRightLine(final int x) {

--- a/widgets/opal/roundedtoolbar/org.eclipse.nebula.widgets.opal.roundedtoolbar/src/org/eclipse/nebula/widgets/opal/roundedtoolbar/RoundedToolbar.java
+++ b/widgets/opal/roundedtoolbar/org.eclipse.nebula.widgets.opal.roundedtoolbar/src/org/eclipse/nebula/widgets/opal/roundedtoolbar/RoundedToolbar.java
@@ -445,6 +445,7 @@ public class RoundedToolbar extends Canvas {
 		gc.drawRoundRectangle(0, 0, width - 1, height - 1, cornerRadius, cornerRadius);
 
 		gc.setClipping((Rectangle) null);
+		path.dispose();
 	}
 
 	/**


### PR DESCRIPTION
It seems that the "MouseMove" event sometimes is notified before the "Paint" event. In "selectKnobs" method the variable "coordLower" is "null" which leads to an NPE

I also fixed 2 memory leaks in the RoundToolBar widget