### PR TITLE
Bug 294 - Dialog.center() should fall back to provided shell

### DIFF
--- a/widgets/opal/dialog/org.eclipse.nebula.widgets.opal.dialog/src/org/eclipse/nebula/widgets/opal/dialog/Dialog.java
+++ b/widgets/opal/dialog/org.eclipse.nebula.widgets.opal.dialog/src/org/eclipse/nebula/widgets/opal/dialog/Dialog.java
@@ -145,6 +145,9 @@ public class Dialog {
 
 		if (centerPolicy == CenterOption.CENTER_ON_SCREEN || shell.getParent() == null) {
 			Shell activeShell = shell.getDisplay().getActiveShell();
+			if (activeShell == null) {
+				activeShell = shell;
+			}
 			final Rectangle monitorBounds = SWTGraphicUtil.getBoundsOfMonitorOnWhichShellIsDisplayed(activeShell);
 			centerX = monitorBounds.x + (monitorBounds.width - preferredSize.x) / 2;
 			centerY = monitorBounds.y + (monitorBounds.height - preferredSize.y) / 2;


### PR DESCRIPTION
If there is no active shell, use the Dialog Shell