### PR TITLE
Issue #304 Grid.onPaint is ineffient on large grids

### DIFF
--- a/releng/org.eclipse.nebula.nebula-parent/pom.xml
+++ b/releng/org.eclipse.nebula.nebula-parent/pom.xml
@@ -22,7 +22,7 @@ Contributors:
 
 	<properties>
 
-		<tycho-version>2.0.0</tycho-version>
+		<tycho-version>2.2.0</tycho-version>
 		<tycho-extras-version>${tycho-version}</tycho-extras-version>
 		<mockito-version>2.8.9</mockito-version>
 		<findbugs-version>2.3.2</findbugs-version>

--- a/widgets/cdatetime/org.eclipse.nebula.widgets.cdatetime.css/META-INF/MANIFEST.MF
+++ b/widgets/cdatetime/org.eclipse.nebula.widgets.cdatetime.css/META-INF/MANIFEST.MF
@@ -11,3 +11,5 @@ Require-Bundle: org.eclipse.swt,
  org.eclipse.nebula.widgets.cdatetime
 Export-Package: org.eclipse.nebula.widgets.cdatetime.css
 Bundle-Vendor: Eclipse.org
+Import-Package: org.w3c.dom;version="2.0.0",
+ org.w3c.dom.css;version="2.0.0"

--- a/widgets/cdatetime/org.eclipse.nebula.widgets.cdatetime.example.e4/META-INF/MANIFEST.MF
+++ b/widgets/cdatetime/org.eclipse.nebula.widgets.cdatetime.example.e4/META-INF/MANIFEST.MF
@@ -18,4 +18,6 @@ Require-Bundle: org.eclipse.swt;bundle-version="0.0.0",
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Automatic-Module-Name: org.eclipse.nebula.widgets.cdatetime.example.e4
 Bundle-ActivationPolicy: lazy
-Import-Package: javax.annotation;version="1.0.0"
+Import-Package: javax.annotation;version="1.0.0",
+ org.w3c.dom;version="2.0.0",
+ org.w3c.dom.css;version="2.0.0"

--- a/widgets/cdatetime/org.eclipse.nebula.widgets.cdatetime.tests/META-INF/MANIFEST.MF
+++ b/widgets/cdatetime/org.eclipse.nebula.widgets.cdatetime.tests/META-INF/MANIFEST.MF
@@ -19,6 +19,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.apache.batik.util;bundle-version="1.8.0",
  org.eclipse.ui;bundle-version="3.109.0",
  org.eclipse.nebula.widgets.cdatetime.css
-Import-Package: org.eclipse.e4.ui.css.core.engine
+Import-Package: org.eclipse.e4.ui.css.core.engine,
+ org.w3c.dom;version="2.0.0",
+ org.w3c.dom.css;version="2.0.0"
 
 

--- a/widgets/grid/org.eclipse.nebula.widgets.grid.css/META-INF/MANIFEST.MF
+++ b/widgets/grid/org.eclipse.nebula.widgets.grid.css/META-INF/MANIFEST.MF
@@ -11,5 +11,5 @@ Require-Bundle: org.eclipse.swt,
  org.eclipse.nebula.widgets.grid
 Export-Package: org.eclipse.nebula.widgets.grid.css
 Bundle-Vendor: Eclipse.org
-Import-Package: org.w3c.dom,
- org.w3c.dom.css
+Import-Package: org.w3c.dom;version="2.0.0",
+ org.w3c.dom.css;version="2.0.0"

--- a/widgets/grid/org.eclipse.nebula.widgets.grid.css/META-INF/MANIFEST.MF
+++ b/widgets/grid/org.eclipse.nebula.widgets.grid.css/META-INF/MANIFEST.MF
@@ -11,3 +11,4 @@ Require-Bundle: org.eclipse.swt,
  org.eclipse.nebula.widgets.grid
 Export-Package: org.eclipse.nebula.widgets.grid.css
 Bundle-Vendor: Eclipse.org
+Import-Package: org.w3c.dom.css

--- a/widgets/grid/org.eclipse.nebula.widgets.grid.css/META-INF/MANIFEST.MF
+++ b/widgets/grid/org.eclipse.nebula.widgets.grid.css/META-INF/MANIFEST.MF
@@ -11,4 +11,5 @@ Require-Bundle: org.eclipse.swt,
  org.eclipse.nebula.widgets.grid
 Export-Package: org.eclipse.nebula.widgets.grid.css
 Bundle-Vendor: Eclipse.org
-Import-Package: org.w3c.dom.css
+Import-Package: org.w3c.dom,
+ org.w3c.dom.css

--- a/widgets/grid/org.eclipse.nebula.widgets.grid/META-INF/MANIFEST.MF
+++ b/widgets/grid/org.eclipse.nebula.widgets.grid/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Nebula Grid
 Bundle-SymbolicName: org.eclipse.nebula.widgets.grid
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.1.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.swt,
  org.eclipse.jface;resolution:=optional

--- a/widgets/grid/org.eclipse.nebula.widgets.grid/pom.xml
+++ b/widgets/grid/org.eclipse.nebula.widgets.grid/pom.xml
@@ -25,4 +25,5 @@ Contributors:
 
 	<artifactId>org.eclipse.nebula.widgets.grid</artifactId>
 	<packaging>eclipse-plugin</packaging>
+	<version>1.1.1-SNAPSHOT</version>
 </project>

--- a/widgets/grid/org.eclipse.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/Grid.java
+++ b/widgets/grid/org.eclipse.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/Grid.java
@@ -7783,17 +7783,21 @@ public class Grid extends Canvas {
 	 */
 	int newColumn(final GridColumn column, final int index) {
 
+		int size = columns.size();
 		if (index == -1) {
-			column.index = columns.size();
+			column.index = size;
 			columns.add(column);
 			displayOrderedColumns.add(column);
 		} else {
 			column.index = index;
 			columns.add(index, column);
+			for(int i = index + 1; i < size; i++) {
+				columns.get(i).index = i;
+			}
 			displayOrderedColumns.add(index, column);
 
 			dataVisualizer.addColumn(index);
-			for (int i = 0; i < columns.size(); i++) {
+			for(int i = 0; i < size; i++) {
 				columns.get(i).setColumnIndex(i);
 			}
 		}
@@ -7812,7 +7816,7 @@ public class Grid extends Canvas {
 		scrollValuesObsolete = true;
 		redraw();
 		clearDisplayOrderedCache();
-		return columns.size() - 1;
+		return size - 1;
 	}
 
 	/**
@@ -7849,6 +7853,10 @@ public class Grid extends Canvas {
 		}
 
 		columns.remove(column);
+		int size = columns.size();
+		for(int i = index; i < size; i++) {
+			columns.get(i).index = i;
+		}
 		displayOrderedColumns.remove(column);
 		dataVisualizer.clearColumn(index);
 

--- a/widgets/grid/org.eclipse.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/Grid.java
+++ b/widgets/grid/org.eclipse.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/Grid.java
@@ -1317,7 +1317,7 @@ public class Grid extends Canvas {
 						continue;
 					}
 
-					final int colIndex = indexOf(displayOrderedColumns.get(i));
+					final int colIndex = displayOrderedColumns.get(i).index;
 					final int span = item.getColumnSpan(colIndex);
 
 					if (i + span >= displayColIndex) {
@@ -4488,7 +4488,7 @@ public class Grid extends Canvas {
 		}
 
 		for (final GridColumn column : columns) {
-			column.getCellRenderer().setColumn(indexOf(column));
+			column.getCellRenderer().setColumn(column.index);
 			height = Math.max(height, column.getCellRenderer().computeSize(gc, SWT.DEFAULT, SWT.DEFAULT, item).y);
 		}
 
@@ -5170,7 +5170,7 @@ public class Grid extends Canvas {
 		final GridColumn column = getColumn(point);
 
 		if (item != null && column != null) {
-			return new Point(columns.indexOf(column), item.getRowIndex());
+			return new Point(column.index, item.getRowIndex());
 		}
 
 		return null;
@@ -5296,7 +5296,7 @@ public class Grid extends Canvas {
 				for (final GridColumn column : displayOrderedColumns) {
 
 					final boolean skipCell = cellSpanManager.skipCell(colIndex, row);
-					final int indexOfColumn = indexOf(column);
+					final int indexOfColumn = column.index;
 
 					if (!column.isVisible()) {
 						colIndex++;
@@ -5461,7 +5461,7 @@ public class Grid extends Canvas {
 						int width = column.width;
 						if(x + width >= 0) {
 							emptyCellRenderer.setBounds(x, y, width, itemHeight);
-							emptyCellRenderer.setColumn(indexOf(column));
+							emptyCellRenderer.setColumn(column.index);
 							emptyCellRenderer.paint(e.gc, this);
 						}
 						if(x > clientArea.width) {
@@ -6181,7 +6181,7 @@ public class Grid extends Canvas {
 					firstLoop2 = false;
 
 					if (currentColumn != null) {
-						final Point cell = new Point(indexOf(currentColumn), currentItem.getRowIndex());
+						final Point cell = new Point(currentColumn.index, currentItem.getRowIndex());
 						addToCellSelection(cell);
 					}
 				} while (currentColumn != endColumn && currentColumn != null);
@@ -6552,12 +6552,12 @@ public class Grid extends Canvas {
 				final GridColumn col = getColumn(new Point(e.x, e.y));
 				boolean isSelectedCell = false;
 				if (col != null) {
-					isSelectedCell = selectedCells.contains(new Point(indexOf(col), item.getRowIndex()));
+					isSelectedCell = selectedCells.contains(new Point(col.index, item.getRowIndex()));
 				}
 
 				if (e.button == 1 || (e.button == 3 && col != null && !isSelectedCell)) {
 					if (col != null) {
-						selectionEvent = updateCellSelection(new Point(indexOf(col), item.getRowIndex()), e.stateMask,
+						selectionEvent = updateCellSelection(new Point(col.index, item.getRowIndex()), e.stateMask,
 								false, true);
 						cellSelectedOnLastMouseDown = (getCellSelectionCount() > 0);
 
@@ -6929,7 +6929,7 @@ public class Grid extends Canvas {
 
 					showColumn(intentColumn);
 					showItem(intentItem);
-					selectionEvent = updateCellSelection(new Point(indexOf(intentColumn), intentItem.getRowIndex()),
+					selectionEvent = updateCellSelection(new Point(intentColumn.index, intentItem.getRowIndex()),
 							ctrlFlag | SWT.MOD2, true, false);
 				}
 				if (cellRowDragSelectionOccuring && handleCellHover(e.x, e.y)) {
@@ -7171,7 +7171,7 @@ public class Grid extends Canvas {
 
 					int index = displayOrderedColumns.indexOf(impliedFocusColumn);
 
-					int jumpAhead = impliedFocusItem.getColumnSpan(indexOf(impliedFocusColumn));
+					int jumpAhead = impliedFocusItem.getColumnSpan(impliedFocusColumn.index);
 
 					jumpAhead++;
 
@@ -7350,7 +7350,7 @@ public class Grid extends Canvas {
 			if (e.stateMask != SWT.MOD1 || isMod1Home(e)) {
 				final int stateMask = e.stateMask == SWT.MOD1 ? SWT.NONE : e.stateMask;
 				final Event selEvent = updateCellSelection(
-						new Point(indexOf(newColumnFocus), newSelection.getRowIndex()), stateMask, false, false);
+						new Point(newColumnFocus.index, newSelection.getRowIndex()), stateMask, false, false);
 				if (selEvent != null) {
 					selEvent.stateMask = stateMask;
 					selEvent.character = e.character;
@@ -7556,7 +7556,7 @@ public class Grid extends Canvas {
 			return false;
 		}
 
-		col.getCellRenderer().setBounds(item.getBounds(indexOf(col)));
+		col.getCellRenderer().setBounds(item.getBounds(col.index));
 		return col.getCellRenderer().notify(IInternalWidget.LeftMouseButtonDown, new Point(x, y), item);
 
 	}
@@ -7595,7 +7595,7 @@ public class Grid extends Canvas {
 		if (col != null) {
 			if (item != null) {
 				if (y < getClientArea().height - (columnFootersVisible ? footerHeight : 0)) {
-					col.getCellRenderer().setBounds(item.getBounds(columns.indexOf(col)));
+					col.getCellRenderer().setBounds(item.getBounds(col.index));
 
 					if (col.getCellRenderer().notify(IInternalWidget.MouseMove, new Point(x, y), item)) {
 						detail = col.getCellRenderer().getHoverDetail();
@@ -7674,7 +7674,7 @@ public class Grid extends Canvas {
 				Rectangle textBounds = null;
 				Rectangle preferredTextBounds = null;
 
-				if (hoveringItem != null && hoveringItem.getToolTipText(indexOf(col)) == null && // no inplace tooltips
+				if(hoveringItem != null && hoveringItem.getToolTipText(col.index) == null && // no inplace tooltips
 						// when regular
 						// tooltip
 						!col.getWordWrap()) // dont show inplace tooltips for cells with wordwrap
@@ -7728,7 +7728,7 @@ public class Grid extends Canvas {
 			String newTip = null;
 			if ((hoveringItem != null) && (hoveringColumn != null)) {
 				// get cell specific tooltip
-				newTip = hoveringItem.getToolTipText(indexOf(hoveringColumn));
+				newTip = hoveringItem.getToolTipText(hoveringColumn.index);
 			} else if ((hoveringColumn != null) && (hoveringColumnHeader != null)) {
 				// get column header specific tooltip
 				newTip = hoveringColumn.getHeaderTooltip();
@@ -7828,7 +7828,7 @@ public class Grid extends Canvas {
 	void removeColumn(final GridColumn column) {
 		boolean selectionModified = false;
 
-		final int index = indexOf(column);
+		final int index = column.index;
 
 		if (cellSelectionEnabled) {
 			final Vector<Point> removeSelectedCells = new Vector<>();
@@ -8147,7 +8147,7 @@ public class Grid extends Canvas {
 		int y = -1;
 
 		if (focusColumn != null) {
-			x = indexOf(focusColumn);
+			x = focusColumn.index;
 		}
 
 		if (focusItem != null) {
@@ -8299,7 +8299,7 @@ public class Grid extends Canvas {
 				continue;
 			}
 
-			if (item.getColumnSpan(indexOf(tempCol)) >= index - j) {
+			if(item.getColumnSpan(tempCol.index) >= index - j) {
 				prevCol = tempCol;
 				break;
 			}
@@ -8340,7 +8340,7 @@ public class Grid extends Canvas {
 			index--;
 			final GridColumn prevCol = displayOrderedColumns.get(index);
 
-			if (item.getColumnSpan(indexOf(prevCol)) >= startIndex - index) {
+			if(item.getColumnSpan(prevCol.index) >= startIndex - index) {
 				if (startIndex == displayOrderedColumns.size() - 1) {
 					return null;
 				} else {
@@ -8667,7 +8667,7 @@ public class Grid extends Canvas {
 		final GridColumn lastCol = getVisibleColumn_DegradeLeft(lastItem,
 				displayOrderedColumns.get(displayOrderedColumns.size() - 1));
 
-		final Event event = updateCellSelection(new Point(indexOf(lastCol), lastItem.getRowIndex()), SWT.MOD2, true,
+		final Event event = updateCellSelection(new Point(lastCol.index, lastItem.getRowIndex()), SWT.MOD2, true,
 				false);
 
 		focusColumn = oldFocusColumn;
@@ -8918,7 +8918,8 @@ public class Grid extends Canvas {
 	}
 
 	private void getCells(final GridColumn col, final Vector<Point> cells) {
-		final int colIndex = indexOf(col);
+
+		final int colIndex = col.index;
 
 		int columnAtPosition = 0;
 		for (final GridColumn nextCol : displayOrderedColumns) {
@@ -8951,7 +8952,7 @@ public class Grid extends Canvas {
 					break;
 				}
 
-				final int span = item.getColumnSpan(indexOf(nextCol));
+				final int span = item.getColumnSpan(nextCol.index);
 
 				if (position + span >= columnAtPosition) {
 					spanned = true;
@@ -8990,9 +8991,9 @@ public class Grid extends Canvas {
 				continue;
 			}
 
-			span = item.getColumnSpan(indexOf(nextCol));
+			span = item.getColumnSpan(nextCol.index);
 
-			cells.add(new Point(indexOf(nextCol), itemIndex));
+			cells.add(new Point(nextCol.index, itemIndex));
 		}
 	}
 
@@ -9014,9 +9015,9 @@ public class Grid extends Canvas {
 				continue;
 			}
 
-			span = item.getColumnSpan(indexOf(nextCol));
+			span = item.getColumnSpan(nextCol.index);
 
-			cells.add(new Point(indexOf(nextCol), itemIndex));
+			cells.add(new Point(nextCol.index, itemIndex));
 		}
 		return cells.toArray(new Point[] {});
 	}
@@ -9078,8 +9079,8 @@ public class Grid extends Canvas {
 		boolean firstTime = true;
 		GridItem iterItem = fromItem;
 
-		final int fromIndex = indexOf(fromColumn);
-		final int toIndex = indexOf(toColumn);
+		final int fromIndex = fromColumn.index;
+		final int toIndex = toColumn.index;
 
 		do {
 			if (!firstTime) {
@@ -9100,7 +9101,7 @@ public class Grid extends Canvas {
 			}
 		} while (iterItem != toItem);
 
-		return new Point(indexOf(fromColumn), indexOf(toColumn));
+		return new Point(fromColumn.index, toColumn.index);
 	}
 
 	/**
@@ -9113,8 +9114,9 @@ public class Grid extends Canvas {
 	 * @return
 	 */
 	private Point getRowSelectionRange(final GridItem item, final GridColumn fromColumn, final GridColumn toColumn) {
-		int newFrom = indexOf(fromColumn);
-		int newTo = indexOf(toColumn);
+
+		int newFrom = fromColumn.index;
+		int newTo = toColumn.index;
 
 		int span = 0;
 		int spanningColIndex = -1;
@@ -9139,11 +9141,11 @@ public class Grid extends Canvas {
 				span--;
 
 				if (spanningBeyondToCol && span == 0) {
-					newTo = indexOf(col);
+					newTo = col.index;
 					break;
 				}
 			} else {
-				final int index = indexOf(col);
+				final int index = col.index;
 				span = item.getColumnSpan(index);
 				if (span > 0) {
 					spanningColIndex = index;
@@ -9187,7 +9189,7 @@ public class Grid extends Canvas {
 					spanningCol = null;
 				}
 			} else {
-				span = item.getColumnSpan(indexOf(col));
+				span = item.getColumnSpan(col.index);
 
 				if (span > 0) {
 					spanningCol = col;
@@ -9241,8 +9243,8 @@ public class Grid extends Canvas {
 			inplaceToolTip.setFont(getFont());
 			inplaceToolTip.setText(group.getText());
 		} else if (item != null) {
-			inplaceToolTip.setFont(item.getFont(item.getParent().indexOf(column)));
-			inplaceToolTip.setText(item.getText(item.getParent().indexOf(column)));
+			inplaceToolTip.setFont(item.getFont(column.index));
+			inplaceToolTip.setText(item.getText(column.index));
 		} else if (column != null) {
 			inplaceToolTip.setFont(getFont());
 			inplaceToolTip.setText(column.getText());

--- a/widgets/grid/org.eclipse.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/Grid.java
+++ b/widgets/grid/org.eclipse.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/Grid.java
@@ -2677,7 +2677,7 @@ public class Grid extends Canvas {
 			}
 		} else {
 			range.rows = range.endIndex - range.startIndex + 1;
-			range.height = (getItemHeight() + 1) * range.rows - 1;
+			range.height = (itemHeight + 1) * range.rows - 1;
 		}
 
 		return range;
@@ -2814,9 +2814,9 @@ public class Grid extends Canvas {
 			range.rows = consumedItems;
 			range.height = consumedHeight;
 		} else {
-			int availableRows = (availableHeight + 1) / (getItemHeight() + 1);
+			int availableRows = (availableHeight + 1) / (itemHeight + 1);
 
-			if (((getItemHeight() + 1) * range.rows - 1) + 1 < availableHeight) {
+			if(((itemHeight + 1) * range.rows - 1) + 1 < availableHeight) {
 				// not all available space used yet
 				// - so add another row if it need not be completely within availableHeight
 				if (!forceEndCompletelyInside) {
@@ -2835,7 +2835,7 @@ public class Grid extends Canvas {
 			range.startIndex = !inverse ? startIndex : otherIndex;
 			range.endIndex = !inverse ? otherIndex : startIndex;
 			range.rows = range.endIndex - range.startIndex + 1;
-			range.height = (getItemHeight() + 1) * range.rows - 1;
+			range.height = (itemHeight + 1) * range.rows - 1;
 		}
 
 		return range;
@@ -5209,13 +5209,13 @@ public class Grid extends Canvas {
 
 		Rectangle clientArea = getClientArea();
 		final int availableHeight = clientArea.height - y;
-		int visibleRows = availableHeight / getItemHeight() + 1;
+		int visibleRows = availableHeight / itemHeight + 1;
 		if (items.size() > 0 && availableHeight > 0) {
 			final RowRange range = getRowRange(getTopIndex(), availableHeight, false, false);
 			if (range.height >= availableHeight) {
 				visibleRows = range.rows;
 			} else {
-				visibleRows = range.rows + (availableHeight - range.height) / getItemHeight() + 1;
+				visibleRows = range.rows + (availableHeight - range.height) / itemHeight + 1;
 			}
 		}
 
@@ -5450,7 +5450,7 @@ public class Grid extends Canvas {
 					x += rowHeaderWidth;
 				}
 
-				emptyCellRenderer.setBounds(x, y, clientArea.width - x, getItemHeight());
+				emptyCellRenderer.setBounds(x, y, clientArea.width - x, itemHeight);
 				emptyCellRenderer.setFocus(false);
 				emptyCellRenderer.setSelected(false);
 				emptyCellRenderer.setRow(i + 1);
@@ -5460,7 +5460,7 @@ public class Grid extends Canvas {
 					if (column.isVisible()) {
 						int width = column.width;
 						if(x + width >= 0) {
-							emptyCellRenderer.setBounds(x, y, width, getItemHeight());
+							emptyCellRenderer.setBounds(x, y, width, itemHeight);
 							emptyCellRenderer.setColumn(indexOf(column));
 							emptyCellRenderer.paint(e.gc, this);
 						}
@@ -5472,7 +5472,7 @@ public class Grid extends Canvas {
 				}
 
 				if (x < clientArea.width) {
-					emptyCellRenderer.setBounds(x, y, clientArea.width - x + 1, getItemHeight());
+					emptyCellRenderer.setBounds(x, y, clientArea.width - x + 1, itemHeight);
 					emptyCellRenderer.setColumn(getColumnCount());
 					emptyCellRenderer.paint(e.gc, this);
 				}
@@ -5480,13 +5480,13 @@ public class Grid extends Canvas {
 				x = 0;
 
 				if (rowHeaderVisible) {
-					emptyRowHeaderRenderer.setBounds(x, y, rowHeaderWidth, getItemHeight() + 1);
+					emptyRowHeaderRenderer.setBounds(x, y, rowHeaderWidth, itemHeight + 1);
 					emptyRowHeaderRenderer.paint(e.gc, this);
 
 					x += rowHeaderWidth;
 				}
 
-				y += getItemHeight() + 1;
+				y += itemHeight + 1;
 			}
 
 			row++;
@@ -5839,7 +5839,7 @@ public class Grid extends Canvas {
 			if (!hasDifferingHeights) {
 				// in this case, the number of visible rows on screen is constant,
 				// so use this as thumb
-				thumb = (getVisibleGridHeight() + 1) / (getItemHeight() + 1);
+				thumb = (getVisibleGridHeight() + 1) / (itemHeight + 1);
 			} else {
 				// in this case, the number of visible rows on screen is variable,
 				// so we have to use 1 as thumb and decrease max by the number of
@@ -9838,7 +9838,7 @@ public class Grid extends Canvas {
 
 			int height = item.getImage(column).getBounds().height;
 			// FIXME Needs better algorithm
-			if (height + 20 > getItemHeight()) {
+			if(height + 20 > itemHeight) {
 				height = computeItemHeight(item);
 				setItemHeight(height);
 			}

--- a/widgets/grid/org.eclipse.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/GridColumn.java
+++ b/widgets/grid/org.eclipse.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/GridColumn.java
@@ -345,7 +345,7 @@ public class GridColumn extends Item {
 
 		cellRenderer.setCheck(check);
 		cellRenderer.setTree(tree);
-		cellRenderer.setColumn(parent.indexOf(this));
+		cellRenderer.setColumn(index);
 
 		if ((getStyle() & SWT.RIGHT) == SWT.RIGHT) {
 			cellRenderer.setAlignment(SWT.RIGHT);
@@ -659,7 +659,7 @@ public class GridColumn extends Item {
 		int newWidth = getHeaderRenderer().computeSize(gc, SWT.DEFAULT,
 				SWT.DEFAULT, this).x;
 
-		getCellRenderer().setColumn(parent.indexOf(this));
+		getCellRenderer().setColumn(index);
 		final boolean virtual = (getParent().getStyle() & SWT.VIRTUAL) != 0;
 		final int bottomIndex = getParent().getBottomIndex() + 1;
 		final int topIndex = getParent().getTopIndex();

--- a/widgets/grid/org.eclipse.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/GridColumn.java
+++ b/widgets/grid/org.eclipse.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/GridColumn.java
@@ -121,7 +121,7 @@ public class GridColumn extends Item {
 	/**
 	 * Width of column.
 	 */
-	private int width = DEFAULT_WIDTH;
+	int width = DEFAULT_WIDTH;
 
 	/**
 	 * Sort style of column. Only used to draw indicator, does not actually sort
@@ -187,6 +187,7 @@ public class GridColumn extends Item {
 	private int minimumWidth = 0;
 
 	private String headerTooltip = null;
+	int index;
 
 	/**
 	 * Constructs a new instance of this class given its parent (which must be a

--- a/widgets/grid/org.eclipse.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/GridColumnGroup.java
+++ b/widgets/grid/org.eclipse.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/GridColumnGroup.java
@@ -177,7 +177,7 @@ public class GridColumnGroup extends Item
         }
 
         GridColumn lastCol = columns[columns.length - 1];
-        return parent.indexOf(lastCol) + 1;
+		return lastCol.index + 1;
     }
 
     void newColumn(GridColumn column, int index)
@@ -232,7 +232,8 @@ public class GridColumnGroup extends Item
     /**
      * {@inheritDoc}
      */
-    public void dispose()
+    @Override
+	public void dispose()
     {
         super.dispose();
 
@@ -329,7 +330,7 @@ public class GridColumnGroup extends Item
             {
                 if (!columns[j].isSummary())
                 {
-                    collapsedCols.add(new Integer(getParent().indexOf(columns[j])));
+					collapsedCols.add(columns[j].index);
                 }
             }
             Point[] selection = getParent().getCellSelection();

--- a/widgets/grid/org.eclipse.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/GridItem.java
+++ b/widgets/grid/org.eclipse.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/GridItem.java
@@ -1301,7 +1301,7 @@ public class GridItem extends Item {
 		GridColumn[] columns = getParent().getColumns();
 
 		for (int i = 0; i < columns.length; i++) {
-			Point cell = new Point(getParent().indexOf(columns[i]), index);
+			Point cell = new Point(columns[i].index, index);
 			if (getParent().isCellSelected(cell)) {
 				flag = true;
 				getParent().deselectCell(cell);

--- a/widgets/oscilloscope/org.eclipse.nebula.widgets.oscilloscope.css/META-INF/MANIFEST.MF
+++ b/widgets/oscilloscope/org.eclipse.nebula.widgets.oscilloscope.css/META-INF/MANIFEST.MF
@@ -11,3 +11,5 @@ Require-Bundle: org.eclipse.swt,
  org.eclipse.e4.ui.css.swt;bundle-version="0.10.0"
 Export-Package: org.eclipse.nebula.widgets.oscilloscope.css
 Bundle-Vendor: Eclipse.org
+Import-Package: org.w3c.dom;version="2.0.0",
+ org.w3c.dom.css;version="2.0.0"

--- a/widgets/pshelf/org.eclipse.nebula.widgets.pshelf.css/META-INF/MANIFEST.MF
+++ b/widgets/pshelf/org.eclipse.nebula.widgets.pshelf.css/META-INF/MANIFEST.MF
@@ -10,3 +10,5 @@ Require-Bundle: org.eclipse.swt;bundle-version="3.8.0",
  org.eclipse.e4.ui.css.core;bundle-version="0.10.0",
  org.eclipse.e4.ui.css.swt;bundle-version="0.10.0"
 Export-Package: org.eclipse.nebula.widgets.pshelf.css
+Import-Package: org.w3c.dom;version="2.0.0",
+ org.w3c.dom.css;version="2.0.0"

--- a/widgets/roundedswitch/org.eclipse.nebula.widgets.roundedswitch.css/META-INF/MANIFEST.MF
+++ b/widgets/roundedswitch/org.eclipse.nebula.widgets.roundedswitch.css/META-INF/MANIFEST.MF
@@ -11,3 +11,5 @@ Require-Bundle: org.eclipse.swt,
  org.eclipse.e4.ui.css.swt;bundle-version="0.10.0"
 Export-Package: org.eclipse.nebula.widgets.roundedswitch.css
 Bundle-Vendor: Eclipse.org
+Import-Package: org.w3c.dom;version="2.0.0",
+ org.w3c.dom.css;version="2.0.0"

--- a/widgets/tablecombo/org.eclipse.nebula.widgets.tablecombo.css/META-INF/MANIFEST.MF
+++ b/widgets/tablecombo/org.eclipse.nebula.widgets.tablecombo.css/META-INF/MANIFEST.MF
@@ -11,3 +11,5 @@ Require-Bundle: org.eclipse.swt,
  org.eclipse.e4.ui.css.swt;bundle-version="0.10.0"
 Export-Package: org.eclipse.nebula.widgets.tablecombo.css
 Bundle-Vendor: Eclipse.org
+Import-Package: org.w3c.dom;version="2.0.0",
+ org.w3c.dom.css;version="2.0.0"


### PR DESCRIPTION
I have don some small adjustments that for my case increases the speed dramatically at least after the final load. I'd like to provide these here as a draft to get some feedback and/or discussions.

- store index on cell to prevent linear list lookups
- don't paint headers that are out of view
- break if width is larger than view