### PR TITLE
Fix a "Widget is Disposed" Exception in the Carousel widget

### DIFF
--- a/widgets/carousel/org.eclipse.nebula.widgets.carousel/src/org/eclipse/nebula/widgets/carousel/ImageContainer.java
+++ b/widgets/carousel/org.eclipse.nebula.widgets.carousel/src/org/eclipse/nebula/widgets/carousel/ImageContainer.java
@@ -58,7 +58,9 @@ class ImageContainer extends Canvas {
 			}
 
 			// Animation
-			gc.drawImage(scrollImage, slider, 0, clientArea.width, clientArea.height, 0, 0, clientArea.width, clientArea.height);
+			if (!scrollImage.isDisposed()) {
+				gc.drawImage(scrollImage, slider, 0, clientArea.width, clientArea.height, 0, 0, clientArea.width, clientArea.height);
+			}
 		});
 	}
 


### PR DESCRIPTION
When playing with the carousel widget I discovered that a WidgetIsDisposed exception is thrown if one navigates too fast.