### PR TITLE
Bug 572341 - decimal format pattern

### DIFF
--- a/widgets/visualization/org.eclipse.nebula.visualization.xygraph.test/src/org/eclipse/nebula/visualization/xygraph/linearscale/AxisTest.java
+++ b/widgets/visualization/org.eclipse.nebula.visualization.xygraph.test/src/org/eclipse/nebula/visualization/xygraph/linearscale/AxisTest.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Diamond Light Source Ltd.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ ******************************************************************************/
+package org.eclipse.nebula.visualization.xygraph.linearscale;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class AxisTest {
+
+	@Test
+	public void testDefaultDecimalFormat() {
+		assertEquals("############.##", AbstractScale.createDefaultDecimalFormat(-30, 30));
+		assertEquals("##.#####", AbstractScale.createDefaultDecimalFormat(-0.001, 0.001));
+	}
+
+}

--- a/widgets/visualization/org.eclipse.nebula.visualization.xygraph/src/org/eclipse/nebula/visualization/xygraph/linearscale/AbstractScale.java
+++ b/widgets/visualization/org.eclipse.nebula.visualization.xygraph/src/org/eclipse/nebula/visualization/xygraph/linearscale/AbstractScale.java
@@ -477,17 +477,7 @@ public abstract class AbstractScale extends Figure {
 
 		// calculate the default decimal format
 		if (formatPattern == null || formatPattern == default_decimal_format) {
-			double f = LargeNumberUtils.maxMagnitude(min, max);
-			double mantissa = Math.abs(max / f - min / f);
-			if (mantissa > 0.1*f) {
-				default_decimal_format = "############.##";
-			} else {
-				default_decimal_format = "##.##";
-				while (mantissa < f) {
-					mantissa *= 10.0;
-					default_decimal_format += "#";
-				}
-			}
+			default_decimal_format = createDefaultDecimalFormat(min, max);
 			formatPattern = default_decimal_format;
 			autoFormat = true;
 		}
@@ -504,6 +494,22 @@ public abstract class AbstractScale extends Figure {
 		setDirty(true);
 		revalidate();
 		repaint();
+	}
+
+	static String createDefaultDecimalFormat(double min, double max) {
+		double f = LargeNumberUtils.maxMagnitude(min, max);
+		double mantissa = Math.abs(max / f - min / f);
+		String decimalFormat;
+		if (mantissa > 0.1/f) {
+			decimalFormat = "############.##";
+		} else {
+			decimalFormat = "##.##";
+			while (mantissa < 1./f) {
+				mantissa *= 10.0;
+				decimalFormat += "#";
+			}
+		}
+		return decimalFormat;
 	}
 
 	protected void internalSetRange(Range range) {


### PR DESCRIPTION
Divide by magnitude when finding sufficient precision for format (omission from fix for [Eclipse 525916](https://bugs.eclipse.org/bugs/show_bug.cgi?id=525916))

Report at [Eclipse 572341](https://bugs.eclipse.org/bugs/show_bug.cgi?id=572341)