### PR TITLE
Bug: - Align formatting of the Notifier sources with the actual formatting standard

### DIFF
--- a/widgets/opal/notifier/org.eclipse.nebula.widgets.opal.notifier.feature/feature.xml
+++ b/widgets/opal/notifier/org.eclipse.nebula.widgets.opal.notifier.feature/feature.xml
@@ -30,4 +30,5 @@
          install-size="0"
          version="0.0.0"
          unpack="false"/>
+
 </feature>

--- a/widgets/opal/notifier/org.eclipse.nebula.widgets.opal.notifier.feature/pom.xml
+++ b/widgets/opal/notifier/org.eclipse.nebula.widgets.opal.notifier.feature/pom.xml
@@ -1,23 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--
-Copyright (C) 2018, Laurent CARON.
-
-All rights reserved. This program and the accompanying materials
-are made available under the terms of the Eclipse Public License v1.0
-which accompanies this distribution, and is available at
-http://www.eclipse.org/legal/epl-v10.html
-
-Contributors:
- * Wim Jongman (RemainSoftware)
- * Mickael Istria (Red Hat Inc.)
--->
+<!-- Copyright (C) 2018, Laurent CARON. All rights reserved. This program 
+	and the accompanying materials are made available under the terms of the 
+	Eclipse Public License v1.0 which accompanies this distribution, and is available 
+	at http://www.eclipse.org/legal/epl-v10.html Contributors: * Wim Jongman 
+	(RemainSoftware) * Mickael Istria (Red Hat Inc.) -->
 
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
 		<groupId>org.eclipse.nebula</groupId>
@@ -25,10 +18,10 @@ Contributors:
 		<artifactId>notifier</artifactId>
 	</parent>
 
-  <artifactId>org.eclipse.nebula.widgets.opal.notifier.feature</artifactId>
-  <packaging>eclipse-feature</packaging>
-  <version>1.0.0-SNAPSHOT</version>
+	<artifactId>org.eclipse.nebula.widgets.opal.notifier.feature</artifactId>
+	<packaging>eclipse-feature</packaging>
+	<version>1.0.0-SNAPSHOT</version>
 
-  <name>Notifier Feature</name>
+	<name>Notifier Feature</name>
 
 </project>

--- a/widgets/opal/notifier/org.eclipse.nebula.widgets.opal.notifier.snippets/pom.xml
+++ b/widgets/opal/notifier/org.eclipse.nebula.widgets.opal.notifier.snippets/pom.xml
@@ -1,16 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--
-Copyright (C) 2018, Laurent CARON.
+<!-- Copyright (C) 2018, Laurent CARON. All rights reserved. This program 
+	and the accompanying materials are made available under the terms of the 
+	Eclipse Public License v1.0 which accompanies this distribution, and is available 
+	at http://www.eclipse.org/legal/epl-v10.html -->
 
-All rights reserved. This program and the accompanying materials
-are made available under the terms of the Eclipse Public License v1.0
-which accompanies this distribution, and is available at
-http://www.eclipse.org/legal/epl-v10.html
--->
-
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
-	xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+	xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>

--- a/widgets/opal/notifier/org.eclipse.nebula.widgets.opal.notifier.snippets/src/org/eclipse/nebula/widgets/opal/notifier/snippets/NotifierSnippet.java
+++ b/widgets/opal/notifier/org.eclipse.nebula.widgets.opal.notifier.snippets/src/org/eclipse/nebula/widgets/opal/notifier/snippets/NotifierSnippet.java
@@ -42,7 +42,8 @@ public class NotifierSnippet {
 		final Button testerYellow = new Button(shell, SWT.PUSH);
 		testerYellow.setText("Push me [Yellow theme]!");
 		testerYellow.addListener(SWT.Selection, event -> {
-			Notifier.notify("New Mail message", "Laurent CARON (lcaron@...)<br/><br/>Test message #" + counter[0] + "...");
+			Notifier.notify("New Mail message",
+					"Laurent CARON (lcaron@...)<br/><br/>Test message #" + counter[0] + "...");
 			counter[0]++;
 		});
 
@@ -50,7 +51,9 @@ public class NotifierSnippet {
 		final Button testerBlue = new Button(shell, SWT.PUSH);
 		testerBlue.setText("Push me [Blue theme]!");
 		testerBlue.addListener(SWT.Selection, event -> {
-			Notifier.notify("New Mail message", "Laurent CARON (lcaron@...)<br/><br/>Test message #" + counter[0] + "...", NotifierTheme.BLUE_THEME);
+			Notifier.notify("New Mail message",
+					"Laurent CARON (lcaron@...)<br/><br/>Test message #" + counter[0] + "...",
+					NotifierTheme.BLUE_THEME);
 			counter[0]++;
 		});
 
@@ -58,7 +61,9 @@ public class NotifierSnippet {
 		final Button testerGrey = new Button(shell, SWT.PUSH);
 		testerGrey.setText("Push me [Gray theme]!");
 		testerGrey.addListener(SWT.Selection, event -> {
-			Notifier.notify("New Mail message", "Laurent CARON (lcaron@...)<br/><br/>Test message #" + counter[0] + "...", NotifierTheme.GRAY_THEME);
+			Notifier.notify("New Mail message",
+					"Laurent CARON (lcaron@...)<br/><br/>Test message #" + counter[0] + "...",
+					NotifierTheme.GRAY_THEME);
 			counter[0]++;
 		});
 

--- a/widgets/opal/notifier/org.eclipse.nebula.widgets.opal.notifier/pom.xml
+++ b/widgets/opal/notifier/org.eclipse.nebula.widgets.opal.notifier/pom.xml
@@ -1,16 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--
-Copyright (C) 2018, Laurent CARON.
+<!-- Copyright (C) 2018, Laurent CARON. All rights reserved. This program 
+	and the accompanying materials are made available under the terms of the 
+	Eclipse Public License v1.0 which accompanies this distribution, and is available 
+	at http://www.eclipse.org/legal/epl-v10.html -->
 
-All rights reserved. This program and the accompanying materials
-are made available under the terms of the Eclipse Public License v1.0
-which accompanies this distribution, and is available at
-http://www.eclipse.org/legal/epl-v10.html
--->
-
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
-	xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+	xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>

--- a/widgets/opal/notifier/org.eclipse.nebula.widgets.opal.notifier/src/org/eclipse/nebula/widgets/opal/notifier/Notifier.java
+++ b/widgets/opal/notifier/org.eclipse.nebula.widgets.opal.notifier/src/org/eclipse/nebula/widgets/opal/notifier/Notifier.java
@@ -46,7 +46,7 @@ public class Notifier {
 	 * will disappear after 4.5 s
 	 *
 	 * @param title the title of the popup window
-	 * @param text the text of the notification
+	 * @param text  the text of the notification
 	 *
 	 */
 	public static void notify(final String title, final String text) {
@@ -58,9 +58,9 @@ public class Notifier {
 	 * will disappear after 4.5 s
 	 *
 	 * @param image the image to display (if <code>null</code>, a default image is
-	 *            displayed)
+	 *              displayed)
 	 * @param title the title of the popup window
-	 * @param text the text of the notification
+	 * @param text  the text of the notification
 	 *
 	 */
 	public static void notify(final Image image, final String title, final String text) {
@@ -73,9 +73,9 @@ public class Notifier {
 	 * will disappear after 4.5 s
 	 *
 	 * @param title the title of the popup window
-	 * @param text the text of the notification
+	 * @param text  the text of the notification
 	 * @param theme the graphical theme. If <code>null</code>, the yellow theme is
-	 *            used
+	 *              used
 	 *
 	 * @see NotifierTheme
 	 */
@@ -88,29 +88,31 @@ public class Notifier {
 	 * will disappear after 4.5 s
 	 *
 	 * @param image the image to display (if <code>null</code>, a default image is
-	 *            displayed)
+	 *              displayed)
 	 * @param title the title of the popup window
-	 * @param text the text of the notification
+	 * @param text  the text of the notification
 	 * @param theme the graphical theme. If <code>null</code>, the yellow theme is
-	 *            used
+	 *              used
 	 *
 	 * @see NotifierTheme
 	 */
 	public static void notify(final Image image, final String title, final String text, final NotifierTheme theme) {
-		final Shell shell = createNotificationWindow(image, title, text, NotifierColorsFactory.getColorsForTheme(theme));
+		final Shell shell = createNotificationWindow(image, title, text,
+				NotifierColorsFactory.getColorsForTheme(theme));
 		makeShellAppears(shell);
 	}
 
 	/**
 	 * Creates a notification window
 	 *
-	 * @param image image. If <code>null</code>, a default image is used
-	 * @param title title, the title of the window
-	 * @param text text of the window
+	 * @param image  image. If <code>null</code>, a default image is used
+	 * @param title  title, the title of the window
+	 * @param text   text of the window
 	 * @param colors color set
 	 * @return the notification window as a shell object
 	 */
-	protected static Shell createNotificationWindow(final Image image, final String title, final String text, final NotifierColors colors) {
+	protected static Shell createNotificationWindow(final Image image, final String title, final String text,
+			final NotifierColors colors) {
 		final Shell shell = new Shell(Display.getDefault().getActiveShell(), SWT.NO_TRIM | SWT.NO_FOCUS | SWT.ON_TOP);
 		shell.setLayout(new GridLayout(2, false));
 		shell.setBackgroundMode(SWT.INHERIT_FORCE);
@@ -133,8 +135,8 @@ public class Notifier {
 	/**
 	 * Creates the title part of the window
 	 *
-	 * @param shell the window
-	 * @param title the title
+	 * @param shell  the window
+	 * @param title  the title
 	 * @param colors the color set
 	 */
 	private static void createTitle(final Shell shell, final String title, final NotifierColors colors) {
@@ -175,8 +177,8 @@ public class Notifier {
 	/**
 	 * Creates the text part of the window
 	 *
-	 * @param shell the window
-	 * @param text the text
+	 * @param shell  the window
+	 * @param text   the text
 	 * @param colors the color set
 	 */
 	private static void createText(final Shell shell, final String text, final NotifierColors colors) {
@@ -202,7 +204,7 @@ public class Notifier {
 	/**
 	 * Creates the background of the window
 	 *
-	 * @param shell the window
+	 * @param shell  the window
 	 * @param colors the color set of the window
 	 */
 	private static void createBackground(final Shell shell, final NotifierColors colors) {
@@ -282,7 +284,7 @@ public class Notifier {
 
 	/**
 	 * @param shell shell that will disappear
-	 * @param fast if true, the fading is much faster
+	 * @param fast  if true, the fading is much faster
 	 * @return a runnable
 	 */
 	private static Runnable fadeOut(final Shell shell, final boolean fast) {
@@ -323,7 +325,8 @@ public class Notifier {
 			final int xUpperLeftCorner = rect.width - 21;
 			final int yUpperLeftCorner = 13;
 
-			if (event.x >= xUpperLeftCorner && event.x <= xUpperLeftCorner + 8 && event.y >= yUpperLeftCorner && event.y <= yUpperLeftCorner + 8) {
+			if (event.x >= xUpperLeftCorner && event.x <= xUpperLeftCorner + 8 && event.y >= yUpperLeftCorner
+					&& event.y <= yUpperLeftCorner + 8) {
 				Display.getDefault().timerExec(0, fadeOut(shell, true));
 			}
 		});

--- a/widgets/opal/notifier/org.eclipse.nebula.widgets.opal.notifier/src/org/eclipse/nebula/widgets/opal/notifier/NotifierColorsFactory.java
+++ b/widgets/opal/notifier/org.eclipse.nebula.widgets.opal.notifier/src/org/eclipse/nebula/widgets/opal/notifier/NotifierColorsFactory.java
@@ -41,27 +41,27 @@ public class NotifierColorsFactory {
 		final NotifierColors colors = new NotifierColors();
 		Display display = Display.getDefault();
 		switch (theme) {
-			case BLUE_THEME:
-				colors.textColor = new Color(display, 4, 64, 140);
-				colors.titleColor = new Color(display, 0, 0, 0);
-				colors.borderColor = new Color(display, 153, 188, 232);
-				colors.leftColor = new Color(display, 210, 225, 244);
-				colors.rightColor = new Color(display, 182, 207, 238);
-				break;
-			case GRAY_THEME:
-				colors.textColor = new Color(display, 0, 0, 0);
-				colors.titleColor = new Color(display, 255, 20, 20);
-				colors.borderColor = new Color(display, 208, 208, 208);
-				colors.leftColor = new Color(display, 255, 255, 255);
-				colors.rightColor = new Color(display, 208, 208, 208);
-				break;
-			default:
-				colors.textColor = new Color(display, 0, 0, 0);
-				colors.titleColor = new Color(display, 0, 0, 0);
-				colors.borderColor = new Color(display, 218, 178, 85);
-				colors.leftColor = new Color(display, 220, 220, 160);
-				colors.rightColor = new Color(display, 255, 255, 191);
-				break;
+		case BLUE_THEME:
+			colors.textColor = new Color(display, 4, 64, 140);
+			colors.titleColor = new Color(display, 0, 0, 0);
+			colors.borderColor = new Color(display, 153, 188, 232);
+			colors.leftColor = new Color(display, 210, 225, 244);
+			colors.rightColor = new Color(display, 182, 207, 238);
+			break;
+		case GRAY_THEME:
+			colors.textColor = new Color(display, 0, 0, 0);
+			colors.titleColor = new Color(display, 255, 20, 20);
+			colors.borderColor = new Color(display, 208, 208, 208);
+			colors.leftColor = new Color(display, 255, 255, 255);
+			colors.rightColor = new Color(display, 208, 208, 208);
+			break;
+		default:
+			colors.textColor = new Color(display, 0, 0, 0);
+			colors.titleColor = new Color(display, 0, 0, 0);
+			colors.borderColor = new Color(display, 218, 178, 85);
+			colors.leftColor = new Color(display, 220, 220, 160);
+			colors.rightColor = new Color(display, 255, 255, 191);
+			break;
 		}
 		return colors;
 	}


### PR DESCRIPTION
Prior to this change, the sources of the notifier plugins were formatted in a format different from the one the actual Eclipse IDE formatter uses.
This would result in a lot of additional format changes when submitting a new pull request; hence, it would be hard for a reviewer to sort out the real funtional changes in the request.

This change reformats the source code of the notifier plugins using the formatter built-in into the Eclipse version 2020-12 to get a clean copy for further pull requests.
It does not contain any functional change whatsoever.

Signed-off-by: Matthias Paul Scholz <matthias.paul.scholz@gmail.com>