### PR TITLE
Remove fixed height from buttonContainer in the PreferenceWindow

### DIFF
--- a/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/src/org/eclipse/nebula/widgets/opal/preferencewindow/PWTabContainer.java
+++ b/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/src/org/eclipse/nebula/widgets/opal/preferencewindow/PWTabContainer.java
@@ -85,7 +85,6 @@ class PWTabContainer extends Composite {
 	private void createContainer() {
 		buttonContainer = new Composite(this, SWT.NONE);
 		final GridData buttonContainerGridData = new GridData(GridData.FILL, GridData.FILL, true, false, 2, 1);
-		buttonContainerGridData.heightHint = 63;
 		buttonContainer.setLayoutData(buttonContainerGridData);
 
 		buttonContainer.setBackground(getDisplay().getSystemColor(SWT.COLOR_WHITE));


### PR DESCRIPTION
We are using 64x64 icon for the PWTab. After we remove the fixed height
the container adjusts itself to the size of the icons.