### PR TITLE
mvn clean verify fails on the root project with DuplicateProjectException

### DIFF
--- a/releng/org.eclipse.nebula.nebula-incubation/pom.xml
+++ b/releng/org.eclipse.nebula.nebula-incubation/pom.xml
@@ -36,8 +36,6 @@ Contributors:
 	<modules>
 		<!-- Dependencies -->
 		<module>../org.eclipse.nebula.nebula-parent</module>
-		<module>../../examples/org.eclipse.nebula.examples</module>
-		<module>../../examples/org.eclipse.nebula.examples.feature</module>
 		<module>../org.eclipse.nebula.examples.incubation.feature</module>
 
 		<module>../../widgets/collapsiblebuttons</module>


### PR DESCRIPTION
Examples shall only be included once in the build. This change allows to
run "mvn clean verify" or "mvn verfify" on the root directory.

Fixes #378