### PR TITLE
Update to Tycho 2.5.0

### DIFF
--- a/releng/org.eclipse.nebula.nebula-parent/pom.xml
+++ b/releng/org.eclipse.nebula.nebula-parent/pom.xml
@@ -22,7 +22,7 @@ Contributors:
 
 	<properties>
 
-		<tycho-version>2.2.0</tycho-version>
+		<tycho-version>2.5.0</tycho-version>
 		<tycho-extras-version>${tycho-version}</tycho-extras-version>
 		<mockito-version>2.8.9</mockito-version>
 		<findbugs-version>2.3.2</findbugs-version>


### PR DESCRIPTION
Examples shall only be included once in the build. This change allows to
run "mvn clean verify" or "mvn verfify" on the root directory.

Fixes #378