### PR TITLE
Revert "Update to Tycho 2.5.0"

### DIFF
--- a/releng/org.eclipse.nebula.nebula-parent/pom.xml
+++ b/releng/org.eclipse.nebula.nebula-parent/pom.xml
@@ -22,7 +22,7 @@ Contributors:
 
 	<properties>
 
-		<tycho-version>2.5.0</tycho-version>
+		<tycho-version>2.2.0</tycho-version>
 		<tycho-extras-version>${tycho-version}</tycho-extras-version>
 		<mockito-version>2.8.9</mockito-version>
 		<findbugs-version>2.3.2</findbugs-version>


### PR DESCRIPTION
Reverts eclipse/nebula#383

[ERROR] Plugin org.eclipse.tycho.extras:tycho-pack200a-plugin:2.5.0 or one of its dependencies could not be resolved: org.eclipse.tycho.extras:tycho-pack200a-plugin:jar:2.5.0 was not found in https://repo.eclipse.org/content/repositories/cbi-releases/ during a previous attempt. This failure was cached in the local repository and resolution is not reattempted until the update interval of cbi has elapsed or updates are forced -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginResolutionException
