### PR TITLE
Allows to build Nebula from top-level directory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,9 +12,21 @@
 	<version>1.0.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
-	<modules>
-		<module>releng/org.eclipse.nebula.nebula-release</module>
-		<module>releng/org.eclipse.nebula.nebula-incubation</module>
-	</modules>
-
+	<profiles>
+ 		<profile>
+  			<id>release</id>
+   			<activation>
+           		<activeByDefault>true</activeByDefault>
+        	</activation>
+			<modules>
+				<module>releng/org.eclipse.nebula.nebula-release</module>	  
+			</modules>
+ 		</profile>
+		 <profile>
+  			<id>incubation</id>
+				<modules>
+					<module>releng/org.eclipse.nebula.nebula-incubation</module>
+				</modules>
+ 		</profile>
+	 </profiles>
 </project>


### PR DESCRIPTION
By default, only the regular widgets are build. Use -Pincubation to
build the incubation components

Fixes #382