### PR TITLE
Class not in sync with BREE in org.eclipse.nebula.cwt.snippets

### DIFF
--- a/widgets/cwt/org.eclipse.nebula.cwt.snippets/.classpath
+++ b/widgets/cwt/org.eclipse.nebula.cwt.snippets/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/widgets/cwt/org.eclipse.nebula.cwt.snippets/.settings/org.eclipse.jdt.core.prefs
+++ b/widgets/cwt/org.eclipse.nebula.cwt.snippets/.settings/org.eclipse.jdt.core.prefs
@@ -1,7 +1,8 @@
-#Sat Jun 28 08:48:22 MDT 2008
 eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.5
-org.eclipse.jdt.core.compiler.compliance=1.5
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.5
+org.eclipse.jdt.core.compiler.release=disabled
+org.eclipse.jdt.core.compiler.source=1.8


### PR DESCRIPTION
Bree defines Java 1.8 but the class is still configured to use Java 1.5.
Fixed with this change.