### PR TITLE
Disable tests that have failures in the command line build

### DIFF
--- a/widgets/cdatetime/org.eclipse.nebula.widgets.cdatetime.tests/pom.xml
+++ b/widgets/cdatetime/org.eclipse.nebula.widgets.cdatetime.tests/pom.xml
@@ -26,6 +26,11 @@ Contributors:
 	<artifactId>org.eclipse.nebula.widgets.cdatetime.tests</artifactId>
 	<version>1.0.0-SNAPSHOT</version>
 	<packaging>eclipse-test-plugin</packaging>
+	
+	<properties>
+		<!-- Currently, test fails see https://github.com/eclipse/nebula/issues/398 -->
+		<skipTests>true</skipTests>
+	</properties>
 
 	<build>
 		<plugins>

--- a/widgets/cwt/org.eclipse.nebula.cwt.tests/pom.xml
+++ b/widgets/cwt/org.eclipse.nebula.cwt.tests/pom.xml
@@ -27,4 +27,9 @@ Contributors:
 	<packaging>eclipse-test-plugin</packaging>
 
 	<version>1.0.0-SNAPSHOT</version>
+	
+	<properties>
+		<!-- Currently, test fails see https://github.com/eclipse/nebula/issues/396 -->
+		<skipTests>true</skipTests>
+	</properties>
 </project>


### PR DESCRIPTION
This will allow us to activate the tests again in the command line
build, as the rest of the tests run successfully.

For #396 and #398