### PR TITLE
Removes a few generated Javadoc comments which repeat @override

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+# This is a workflow that builds on pushes to the main branch
+
+name: Build on Windows
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+jobs: 
+  build:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 11
+      uses: actions/setup-java@v2
+      with:
+        java-version: 11
+        distribution: 'adopt'
+    - name: Cache local Maven repository
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
+    - name: Build with Maven
+      run: mvn clean verify surefire-report:report --fae --file releng/org.eclipse.nebula.nebula-release/pom.xml -T4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,4 +28,4 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-maven-
     - name: Build with Maven
-      run: mvn clean verify surefire-report:report --fae --file releng/org.eclipse.nebula.nebula-release/pom.xml -T4
+      run: mvn clean verify surefire-report:report --fae --file releng/org.eclipse.nebula.nebula-release/pom.xml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ name: Build on Windows
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,8 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
+
 jobs: 
   build:
     runs-on: windows-latest

--- a/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/src/org/eclipse/nebula/widgets/opal/preferencewindow/enabler/EnabledIfEquals.java
+++ b/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/src/org/eclipse/nebula/widgets/opal/preferencewindow/enabler/EnabledIfEquals.java
@@ -33,9 +33,6 @@ public class EnabledIfEquals extends Enabler {
 		this.value = value;
 	}
 
-	/**
-	 * @see org.eclipse.nebula.widgets.opal.preferencewindow.enabler.Enabler#isEnabled()
-	 */
 	@Override
 	public boolean isEnabled() {
 		final Object propValue = PreferenceWindow.getInstance().getValueFor(this.prop);

--- a/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/src/org/eclipse/nebula/widgets/opal/preferencewindow/enabler/EnabledIfNotEquals.java
+++ b/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/src/org/eclipse/nebula/widgets/opal/preferencewindow/enabler/EnabledIfNotEquals.java
@@ -33,9 +33,6 @@ public class EnabledIfNotEquals extends Enabler {
 		this.value = value;
 	}
 
-	/**
-	 * @see org.eclipse.nebula.widgets.opal.preferencewindow.enabler.Enabler#isEnabled()
-	 */
 	@Override
 	public boolean isEnabled() {
 		final Object propValue = PreferenceWindow.getInstance().getValueFor(this.prop);

--- a/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/src/org/eclipse/nebula/widgets/opal/preferencewindow/enabler/EnabledIfTrue.java
+++ b/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/src/org/eclipse/nebula/widgets/opal/preferencewindow/enabler/EnabledIfTrue.java
@@ -29,9 +29,6 @@ public class EnabledIfTrue extends Enabler {
 		super(prop);
 	}
 
-	/**
-	 * @see org.eclipse.nebula.widgets.opal.preferencewindow.enabler.Enabler#isEnabled()
-	 */
 	@Override
 	public boolean isEnabled() {
 		final Object value = PreferenceWindow.getInstance().getValueFor(this.prop);


### PR DESCRIPTION
Eclipse platform used to generate these ugly comments for code which was
below Java 1.5 to have a substibute for @override. These days such
comments can and should be removed to reduce the code to the important
bits.