### PR TITLE
Removes a few generated Javadoc comments which repeat @override

### DIFF
--- a/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/src/org/eclipse/nebula/widgets/opal/preferencewindow/widgets/PWButton.java
+++ b/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/src/org/eclipse/nebula/widgets/opal/preferencewindow/widgets/PWButton.java
@@ -37,9 +37,6 @@ public class PWButton extends PWWidget {
 		this.listener = listener;
 	}
 
-	/**
-	 * @see org.eclipse.nebula.widgets.opal.preferencewindow.widgets.PWWidget#build(org.eclipse.swt.widgets.Composite)
-	 */
 	@Override
 	public Control build(final Composite parent) {
 		final Button button = new Button(parent, SWT.PUSH);
@@ -57,9 +54,6 @@ public class PWButton extends PWWidget {
 
 	}
 
-	/**
-	 * @see org.eclipse.nebula.widgets.opal.preferencewindow.widgets.PWWidget#check()
-	 */
 	@Override
 	public void check() {
 	}

--- a/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/src/org/eclipse/nebula/widgets/opal/preferencewindow/widgets/PWColorChooser.java
+++ b/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/src/org/eclipse/nebula/widgets/opal/preferencewindow/widgets/PWColorChooser.java
@@ -46,9 +46,6 @@ public class PWColorChooser extends PWWidget {
 		super(label, propertyKey, label == null ? 1 : 2, false);
 	}
 
-	/**
-	 * @see org.eclipse.nebula.widgets.opal.preferencewindow.widgets.PWWidget#build(org.eclipse.swt.widgets.Composite)
-	 */
 	@Override
 	public Control build(final Composite parent) {
 		final RGB rgb = (RGB) PreferenceWindow.getInstance().getValueFor(getPropertyKey());
@@ -104,9 +101,6 @@ public class PWColorChooser extends PWWidget {
 		button.setImage(newImage);
 	}
 
-	/**
-	 * @see org.eclipse.nebula.widgets.opal.preferencewindow.widgets.PWWidget#check()
-	 */
 	@Override
 	public void check() {
 		final Object value = PreferenceWindow.getInstance().getValueFor(getPropertyKey());

--- a/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/src/org/eclipse/nebula/widgets/opal/preferencewindow/widgets/PWCombo.java
+++ b/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/src/org/eclipse/nebula/widgets/opal/preferencewindow/widgets/PWCombo.java
@@ -55,9 +55,6 @@ public class PWCombo extends PWWidget {
 		this.editable = editable;
 	}
 
-	/**
-	 * @see org.eclipse.nebula.widgets.opal.preferencewindow.widgets.PWWidget#build(org.eclipse.swt.widgets.Composite)
-	 */
 	@Override
 	public Control build(final Composite parent) {
 		buildLabel(parent, GridData.CENTER);
@@ -80,9 +77,6 @@ public class PWCombo extends PWWidget {
 		return combo;
 	}
 
-	/**
-	 * @see org.eclipse.nebula.widgets.opal.preferencewindow.widgets.PWWidget#check()
-	 */
 	@Override
 	public void check() {
 		final Object value = PreferenceWindow.getInstance().getValueFor(getPropertyKey());

--- a/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/src/org/eclipse/nebula/widgets/opal/preferencewindow/widgets/PWDirectoryChooser.java
+++ b/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/src/org/eclipse/nebula/widgets/opal/preferencewindow/widgets/PWDirectoryChooser.java
@@ -34,10 +34,6 @@ public class PWDirectoryChooser extends PWChooser {
 		super(label, propertyKey);
 	}
 
-	/**
-	 * @see org.eclipse.nebula.widgets.opal.preferencewindow.widgets.PWChooser#setButtonAction(org.eclipse.swt.widgets.Text,
-	 *      org.eclipse.swt.widgets.Button)
-	 */
 	@Override
 	protected void setButtonAction(final Text text, final Button button) {
 
@@ -55,9 +51,6 @@ public class PWDirectoryChooser extends PWChooser {
 		});
 	}
 
-	/**
-	 * @see org.eclipse.nebula.widgets.opal.preferencewindow.widgets.PWWidget#check()
-	 */
 	@Override
 	public void check() {
 		final Object value = PreferenceWindow.getInstance().getValueFor(getPropertyKey());

--- a/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/src/org/eclipse/nebula/widgets/opal/preferencewindow/widgets/PWFileChooser.java
+++ b/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/src/org/eclipse/nebula/widgets/opal/preferencewindow/widgets/PWFileChooser.java
@@ -34,10 +34,6 @@ public class PWFileChooser extends PWChooser {
 		super(label, propertyKey);
 	}
 
-	/**
-	 * @see org.eclipse.nebula.widgets.opal.preferencewindow.widgets.PWChooser#setButtonAction(org.eclipse.swt.widgets.Text,
-	 *      org.eclipse.swt.widgets.Button)
-	 */
 	@Override
 	protected void setButtonAction(final Text text, final Button button) {
 		final String originalFile = (String) PreferenceWindow.getInstance().getValueFor(getPropertyKey());
@@ -54,9 +50,6 @@ public class PWFileChooser extends PWChooser {
 
 	}
 
-	/**
-	 * @see org.eclipse.nebula.widgets.opal.preferencewindow.widgets.PWWidget#check()
-	 */
 	@Override
 	public void check() {
 		final Object value = PreferenceWindow.getInstance().getValueFor(getPropertyKey());

--- a/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/src/org/eclipse/nebula/widgets/opal/preferencewindow/widgets/PWFloatText.java
+++ b/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/src/org/eclipse/nebula/widgets/opal/preferencewindow/widgets/PWFloatText.java
@@ -31,9 +31,6 @@ public class PWFloatText extends PWText {
 		super(label, propertyKey);
 	}
 
-	/**
-	 * @see org.eclipse.nebula.widgets.opal.preferencewindow.widgets.PWText#addVerifyListeners()
-	 */
 	@Override
 	public void addVerifyListeners() {
 		text.addListener(SWT.Verify, e -> {
@@ -75,9 +72,6 @@ public class PWFloatText extends PWText {
 		return true;
 	}
 
-	/**
-	 * @see org.eclipse.nebula.widgets.opal.preferencewindow.widgets.PWWidget#check()
-	 */
 	@Override
 	public void check() {
 		final Object value = PreferenceWindow.getInstance().getValueFor(getPropertyKey());
@@ -90,17 +84,11 @@ public class PWFloatText extends PWText {
 		}
 	}
 
-	/**
-	 * @see org.eclipse.nebula.widgets.opal.preferencewindow.widgets.PWText#convertValue()
-	 */
 	@Override
 	public Object convertValue() {
 		return Float.parseFloat(text.getText());
 	}
 
-	/**
-	 * @see org.eclipse.nebula.widgets.opal.preferencewindow.widgets.PWText#getStyle()
-	 */
 	@Override
 	public int getStyle() {
 		return SWT.NONE;

--- a/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/src/org/eclipse/nebula/widgets/opal/preferencewindow/widgets/PWLabel.java
+++ b/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/src/org/eclipse/nebula/widgets/opal/preferencewindow/widgets/PWLabel.java
@@ -37,9 +37,6 @@ public class PWLabel extends PWWidget {
 		setGrabExcessSpace(true);
 	}
 
-	/**
-	 * @see org.eclipse.nebula.widgets.opal.preferencewindow.widgets.PWWidget#build(org.eclipse.swt.widgets.Composite)
-	 */
 	@Override
 	public Control build(final Composite parent) {
 		if (getLabel() == null) {
@@ -53,16 +50,10 @@ public class PWLabel extends PWWidget {
 		return labelWidget;
 	}
 
-	/**
-	 * @see org.eclipse.nebula.widgets.opal.preferencewindow.widgets.PWWidget#check()
-	 */
 	@Override
 	public void check() {
 	}
 
-	/**
-	 * @see org.eclipse.nebula.widgets.opal.preferencewindow.widgets.PWWidget#enableOrDisable()
-	 */
 	@Override
 	public boolean enableOrDisable() {
 		if (enabler == null) {

--- a/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/src/org/eclipse/nebula/widgets/opal/preferencewindow/widgets/PWRadio.java
+++ b/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/src/org/eclipse/nebula/widgets/opal/preferencewindow/widgets/PWRadio.java
@@ -46,9 +46,6 @@ public class PWRadio extends PWWidget {
 		buttons = new ArrayList<Button>();
 	}
 
-	/**
-	 * @see org.eclipse.nebula.widgets.opal.preferencewindow.widgets.PWWidget#build(org.eclipse.swt.widgets.Composite)
-	 */
 	@Override
 	public Control build(final Composite parent) {
 		buildLabel(parent, GridData.BEGINNING);
@@ -76,9 +73,6 @@ public class PWRadio extends PWWidget {
 		return composite;
 	}
 
-	/**
-	 * @see org.eclipse.nebula.widgets.opal.preferencewindow.widgets.PWWidget#check()
-	 */
 	@Override
 	public void check() {
 		final Object value = PreferenceWindow.getInstance().getValueFor(getPropertyKey());

--- a/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/src/org/eclipse/nebula/widgets/opal/preferencewindow/widgets/PWScale.java
+++ b/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/src/org/eclipse/nebula/widgets/opal/preferencewindow/widgets/PWScale.java
@@ -45,9 +45,6 @@ public class PWScale extends PWWidget {
 		this.increment = increment;
 	}
 
-	/**
-	 * @see org.eclipse.nebula.widgets.opal.preferencewindow.widgets.PWWidget#build(org.eclipse.swt.widgets.Composite)
-	 */
 	@Override
 	public Control build(final Composite parent) {
 		buildLabel(parent, GridData.CENTER);
@@ -64,9 +61,6 @@ public class PWScale extends PWWidget {
 		return scale;
 	}
 
-	/**
-	 * @see org.eclipse.nebula.widgets.opal.preferencewindow.widgets.PWWidget#check()
-	 */
 	@Override
 	public void check() {
 		final Object value = PreferenceWindow.getInstance().getValueFor(getPropertyKey());

--- a/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/src/org/eclipse/nebula/widgets/opal/preferencewindow/widgets/PWSeparator.java
+++ b/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/src/org/eclipse/nebula/widgets/opal/preferencewindow/widgets/PWSeparator.java
@@ -58,9 +58,6 @@ public class PWSeparator extends PWWidget {
 		setHeight(20);
 	}
 
-	/**
-	 * @see org.eclipse.nebula.widgets.opal.preferencewindow.widgets.PWWidget#build(org.eclipse.swt.widgets.Composite)
-	 */
 	@Override
 	public Control build(final Composite parent) {
 		final TitledSeparator sep = new TitledSeparator(parent, SWT.NONE);
@@ -70,9 +67,6 @@ public class PWSeparator extends PWWidget {
 		return sep;
 	}
 
-	/**
-	 * @see org.eclipse.nebula.widgets.opal.preferencewindow.widgets.PWWidget#check()
-	 */
 	@Override
 	public void check() {
 	}

--- a/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/src/org/eclipse/nebula/widgets/opal/preferencewindow/widgets/PWSpinner.java
+++ b/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/src/org/eclipse/nebula/widgets/opal/preferencewindow/widgets/PWSpinner.java
@@ -41,9 +41,6 @@ public class PWSpinner extends PWWidget {
 		this.max = max;
 	}
 
-	/**
-	 * @see org.eclipse.nebula.widgets.opal.preferencewindow.widgets.PWWidget#build(org.eclipse.swt.widgets.Composite)
-	 */
 	@Override
 	public Control build(final Composite parent) {
 		buildLabel(parent, GridData.CENTER);
@@ -61,9 +58,6 @@ public class PWSpinner extends PWWidget {
 		return spinner;
 	}
 
-	/**
-	 * @see org.eclipse.nebula.widgets.opal.preferencewindow.widgets.PWWidget#check()
-	 */
 	@Override
 	public void check() {
 		final Object value = PreferenceWindow.getInstance().getValueFor(getPropertyKey());

--- a/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/src/org/eclipse/nebula/widgets/opal/preferencewindow/widgets/PWStringText.java
+++ b/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/src/org/eclipse/nebula/widgets/opal/preferencewindow/widgets/PWStringText.java
@@ -31,16 +31,10 @@ public class PWStringText extends PWText {
 		super(label, propertyKey);
 	}
 
-	/**
-	 * @see org.eclipse.nebula.widgets.opal.preferencewindow.widgets.PWText#addVerifyListeners()
-	 */
 	@Override
 	public void addVerifyListeners() {
 	}
 
-	/**
-	 * @see org.eclipse.nebula.widgets.opal.preferencewindow.widgets.PWWidget#check()
-	 */
 	@Override
 	public void check() {
 		final Object value = PreferenceWindow.getInstance().getValueFor(getPropertyKey());
@@ -53,17 +47,11 @@ public class PWStringText extends PWText {
 		}
 	}
 
-	/**
-	 * @see org.eclipse.nebula.widgets.opal.preferencewindow.widgets.PWText#convertValue()
-	 */
 	@Override
 	public Object convertValue() {
 		return this.text.getText();
 	}
 
-	/**
-	 * @see org.eclipse.nebula.widgets.opal.preferencewindow.widgets.PWText#getStyle()
-	 */
 	@Override
 	public int getStyle() {
 		return SWT.NONE;

--- a/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/src/org/eclipse/nebula/widgets/opal/preferencewindow/widgets/PWText.java
+++ b/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/src/org/eclipse/nebula/widgets/opal/preferencewindow/widgets/PWText.java
@@ -38,9 +38,6 @@ public abstract class PWText extends PWWidget {
 		setGrabExcessSpace(true);
 	}
 
-	/**
-	 * @see org.eclipse.nebula.widgets.opal.preferencewindow.widgets.PWWidget#build(org.eclipse.swt.widgets.Composite)
-	 */
 	@Override
 	public Control build(final Composite parent) {
 		buildLabel(parent, GridData.CENTER);

--- a/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/src/org/eclipse/nebula/widgets/opal/preferencewindow/widgets/PWTextarea.java
+++ b/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/src/org/eclipse/nebula/widgets/opal/preferencewindow/widgets/PWTextarea.java
@@ -39,9 +39,6 @@ public class PWTextarea extends PWWidget {
 		setWidth(350);
 	}
 
-	/**
-	 * @see org.eclipse.nebula.widgets.opal.preferencewindow.widgets.PWWidget#build(org.eclipse.swt.widgets.Composite)
-	 */
 	@Override
 	public Control build(final Composite parent) {
 		buildLabel(parent, GridData.BEGINNING);
@@ -56,9 +53,6 @@ public class PWTextarea extends PWWidget {
 		return text;
 	}
 
-	/**
-	 * @see org.eclipse.nebula.widgets.opal.preferencewindow.widgets.PWWidget#check()
-	 */
 	@Override
 	public void check() {
 		final Object value = PreferenceWindow.getInstance().getValueFor(getPropertyKey());

--- a/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/src/org/eclipse/nebula/widgets/opal/preferencewindow/widgets/PWURLText.java
+++ b/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/src/org/eclipse/nebula/widgets/opal/preferencewindow/widgets/PWURLText.java
@@ -36,9 +36,6 @@ public class PWURLText extends PWText {
 		setWidth(200);
 	}
 
-	/**
-	 * @see org.eclipse.nebula.widgets.opal.preferencewindow.widgets.PWText#addVerifyListeners()
-	 */
 	@Override
 	public void addVerifyListeners() {
 		text.addListener(SWT.FocusOut, event -> {
@@ -53,9 +50,6 @@ public class PWURLText extends PWText {
 
 	}
 
-	/**
-	 * @see org.eclipse.nebula.widgets.opal.preferencewindow.widgets.PWWidget#check()
-	 */
 	@Override
 	public void check() {
 		final Object value = PreferenceWindow.getInstance().getValueFor(getPropertyKey());
@@ -80,17 +74,11 @@ public class PWURLText extends PWText {
 		}
 	}
 
-	/**
-	 * @see org.eclipse.nebula.widgets.opal.preferencewindow.widgets.PWText#convertValue()
-	 */
 	@Override
 	public Object convertValue() {
 		return text.getText();
 	}
 
-	/**
-	 * @see org.eclipse.nebula.widgets.opal.preferencewindow.widgets.PWText#getStyle()
-	 */
 	@Override
 	public int getStyle() {
 		return SWT.NONE;


### PR DESCRIPTION
Eclipse platform used to generate these ugly comments for code which was
below Java 1.5 to have a substibute for @override. These days such
comments can and should be removed to reduce the code to the important
bits.