### PR TITLE
Removes  generated Javadoc comments in preferencewindow.enabler

### DIFF
--- a/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/src/org/eclipse/nebula/widgets/opal/preferencewindow/enabler/EnabledIfEquals.java
+++ b/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/src/org/eclipse/nebula/widgets/opal/preferencewindow/enabler/EnabledIfEquals.java
@@ -33,9 +33,6 @@ public class EnabledIfEquals extends Enabler {
 		this.value = value;
 	}
 
-	/**
-	 * @see org.eclipse.nebula.widgets.opal.preferencewindow.enabler.Enabler#isEnabled()
-	 */
 	@Override
 	public boolean isEnabled() {
 		final Object propValue = PreferenceWindow.getInstance().getValueFor(this.prop);

--- a/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/src/org/eclipse/nebula/widgets/opal/preferencewindow/enabler/EnabledIfNotEquals.java
+++ b/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/src/org/eclipse/nebula/widgets/opal/preferencewindow/enabler/EnabledIfNotEquals.java
@@ -33,9 +33,6 @@ public class EnabledIfNotEquals extends Enabler {
 		this.value = value;
 	}
 
-	/**
-	 * @see org.eclipse.nebula.widgets.opal.preferencewindow.enabler.Enabler#isEnabled()
-	 */
 	@Override
 	public boolean isEnabled() {
 		final Object propValue = PreferenceWindow.getInstance().getValueFor(this.prop);

--- a/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/src/org/eclipse/nebula/widgets/opal/preferencewindow/enabler/EnabledIfTrue.java
+++ b/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/src/org/eclipse/nebula/widgets/opal/preferencewindow/enabler/EnabledIfTrue.java
@@ -29,9 +29,6 @@ public class EnabledIfTrue extends Enabler {
 		super(prop);
 	}
 
-	/**
-	 * @see org.eclipse.nebula.widgets.opal.preferencewindow.enabler.Enabler#isEnabled()
-	 */
 	@Override
 	public boolean isEnabled() {
 		final Object value = PreferenceWindow.getInstance().getValueFor(this.prop);


### PR DESCRIPTION
Eclipse platform used to generate these ugly comments for code which was
below Java 1.5 to have a substibute for @override. These days such
comments can and should be removed to reduce the code to the important
bits.