### PR TITLE
Fixes SWT Resource was not properly disposed in PWColorChooser

### DIFF
--- a/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/src/org/eclipse/nebula/widgets/opal/preferencewindow/widgets/PWColorChooser.java
+++ b/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/src/org/eclipse/nebula/widgets/opal/preferencewindow/widgets/PWColorChooser.java
@@ -102,6 +102,8 @@ public class PWColorChooser extends PWWidget {
 		gc.dispose();
 
 		button.setImage(newImage);
+		
+		button.addDisposeListener(e -> newImage.dispose());
 	}
 
 	/**


### PR DESCRIPTION
ava.lang.Error: SWT Resource was not properly disposed
	at org.eclipse.swt.graphics.Resource.initNonDisposeTracking(Resource.java:172)
	at org.eclipse.swt.graphics.Resource.<init>(Resource.java:120)
	at org.eclipse.swt.graphics.Image.<init>(Image.java:205)
	at org.eclipse.nebula.widgets.opal.preferencewindow.widgets.PWColorChooser.drawButton(PWColorChooser.java:93)
	at org.eclipse.nebula.widgets.opal.preferencewindow.widgets.PWColorChooser$1.handleEvent(PWColorChooser.java:69)