### PR TITLE
Resolve #439 - Adding configuration to disable autoformatting URLs in IE

### DIFF
--- a/releng/org.eclipse.nebula.updatesite/category.xml
+++ b/releng/org.eclipse.nebula.updatesite/category.xml
@@ -18,7 +18,7 @@
    <feature url="features/org.eclipse.nebula.widgets.grid.css.feature_1.1.0.qualifier.jar" id="org.eclipse.nebula.widgets.grid.css.feature" version="1.1.0.qualifier">
       <category name="Nebula Release Individual Widgets"/>
    </feature>
-   <feature url="features/org.eclipse.nebula.widgets.richtext.feature_1.4.0.qualifier.jar" id="org.eclipse.nebula.widgets.richtext.feature" version="1.4.1.qualifier">
+   <feature url="features/org.eclipse.nebula.widgets.richtext.feature_1.5.0.qualifier.jar" id="org.eclipse.nebula.widgets.richtext.feature" version="1.5.0.qualifier">
       <category name="Nebula Release Individual Widgets"/>
    </feature>
    <feature url="features/org.eclipse.nebula.widgets.paperclips.feature_2.1.0.qualifier.jar" id="org.eclipse.nebula.widgets.paperclips.feature" version="2.1.0.qualifier">

--- a/widgets/richtext/org.eclipse.nebula.widgets.richtext.feature/feature.xml
+++ b/widgets/richtext/org.eclipse.nebula.widgets.richtext.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.nebula.widgets.richtext.feature"
       label="Nebula RichText Feature"
-      version="1.4.1.qualifier"
+      version="1.5.0.qualifier"
       provider-name="Eclipse Nebula">
 
    <description url="http://eclipse.org/nebula">

--- a/widgets/richtext/org.eclipse.nebula.widgets.richtext.feature/pom.xml
+++ b/widgets/richtext/org.eclipse.nebula.widgets.richtext.feature/pom.xml
@@ -35,7 +35,7 @@ Contributors:
 
   <artifactId>org.eclipse.nebula.widgets.richtext.feature</artifactId>
   <packaging>eclipse-feature</packaging>
-  <version>1.4.1-SNAPSHOT</version>
+  <version>1.5.0-SNAPSHOT</version>
 
   <name>Nebula RichText Widget</name>
 </project>

--- a/widgets/richtext/org.eclipse.nebula.widgets.richtext/META-INF/MANIFEST.MF
+++ b/widgets/richtext/org.eclipse.nebula.widgets.richtext/META-INF/MANIFEST.MF
@@ -2,13 +2,13 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Nebula Richtext Widget
 Bundle-SymbolicName: org.eclipse.nebula.widgets.richtext
-Bundle-Version: 1.4.1.qualifier
+Bundle-Version: 1.5.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.swt;bundle-version="3.103.0",
  org.eclipse.jface,
  org.eclipse.core.runtime
 Eclipse-BundleShape: dir
-Export-Package: org.eclipse.nebula.widgets.richtext;version="1.4.0",
+Export-Package: org.eclipse.nebula.widgets.richtext;version="1.5.0",
  org.eclipse.nebula.widgets.richtext.painter;version="1.2.0",
  org.eclipse.nebula.widgets.richtext.painter.instructions;version="1.3.0",
  org.eclipse.nebula.widgets.richtext.toolbar;version="1.2.0"

--- a/widgets/richtext/org.eclipse.nebula.widgets.richtext/pom.xml
+++ b/widgets/richtext/org.eclipse.nebula.widgets.richtext/pom.xml
@@ -25,6 +25,6 @@ Contributors:
 
 	<artifactId>org.eclipse.nebula.widgets.richtext</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>1.4.1-SNAPSHOT</version>
+	<version>1.5.0-SNAPSHOT</version>
  
 </project>

--- a/widgets/richtext/org.eclipse.nebula.widgets.richtext/src/org/eclipse/nebula/widgets/richtext/RichTextEditor.java
+++ b/widgets/richtext/org.eclipse.nebula.widgets.richtext/src/org/eclipse/nebula/widgets/richtext/RichTextEditor.java
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2015, 2020 CEA LIST.
+ * Copyright (c) 2015, 2022 CEA LIST.
  *
  *
  * This program and the accompanying materials
@@ -288,6 +288,10 @@ public class RichTextEditor extends Composite {
 				CKEDITOR_SHIFT = (Double) browser.evaluate("return getCKEditorSHIFT()");
 
 				editorLoaded = true;
+
+				if (RichTextEditor.this.editorConfig.isAutoUrlFormattingDisabled()) {
+					browser.evaluate("document.execCommand('AutoUrlDetect', false, false);");
+				}
 
 				// only add this function for resizable inline editing
 				if (resizable && embedded) {

--- a/widgets/richtext/org.eclipse.nebula.widgets.richtext/src/org/eclipse/nebula/widgets/richtext/RichTextEditorConfiguration.java
+++ b/widgets/richtext/org.eclipse.nebula.widgets.richtext/src/org/eclipse/nebula/widgets/richtext/RichTextEditorConfiguration.java
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2016, 2019 Dirk Fauth.
+ * Copyright (c) 2016, 2022 Dirk Fauth.
  *
  *
  * This program and the accompanying materials
@@ -150,6 +150,11 @@ public class RichTextEditorConfiguration {
 	 * Default is <code>true</code>.
 	 */
 	private boolean removeFormat = true;
+
+	/**
+	 * Configure if the IE should auto format URLs or not.
+	 */
+	private boolean autoUrlFormattingDisabled = false;
 
 	private Set<String> removedButtons = new HashSet<>();
 
@@ -642,4 +647,28 @@ public class RichTextEditorConfiguration {
 		}
 	}
 
+	/**
+	 * 
+	 * @return <code>true</code> if the auto-formatting of URLs in IE is disabled,
+	 *         <code>false</code> if not.
+	 *
+	 * @since 1.5
+	 */
+	public boolean isAutoUrlFormattingDisabled() {
+		return this.autoUrlFormattingDisabled;
+	}
+
+	/**
+	 * Configure if the auto-formatting of URLs should be disabled on Windows systems with an
+	 * Internet Explorer as system browser.
+	 * 
+	 * @param autoUrlFormattingDisabled
+	 *            <code>true</code> if the auto-formatting of URLs in IE should be disabled,
+	 *            <code>false</code> if not.
+	 * 
+	 * @since 1.5
+	 */
+	public void setAutoUrlFormattingDisabled(boolean autoUrlFormattingDisabled) {
+		this.autoUrlFormattingDisabled = autoUrlFormattingDisabled;
+	}
 }


### PR DESCRIPTION
With this PR it is possible to disable the auto-formatting of URLs in IE via `RichTextEditorConfiguration`, e.g.

	RichTextEditorConfiguration editorConfig = new RichTextEditorConfiguration();
	editorConfig.setAutoUrlFormattingDisabled(true);
	RichTextEditor editor = new RichTextEditor(parent, editorConfig);

Signed-off-by: Dirk Fauth <dirk.fauth@googlemail.com>