### PR TITLE
Bug #499 - TableComboViewer dropdown not closed automatically

### DIFF
--- a/widgets/tablecombo/org.eclipse.nebula.widgets.tablecombo/src/org/eclipse/nebula/widgets/tablecombo/TableCombo.java
+++ b/widgets/tablecombo/org.eclipse.nebula.widgets.tablecombo/src/org/eclipse/nebula/widgets/tablecombo/TableCombo.java
@@ -584,7 +584,11 @@ public class TableCombo extends Composite {
 			if (focusControl == arrow || focusControl == table) {
 				return;
 			}
-			if (!isDropped()) {
+			if (isDropped()) {
+				if (isWindows()) {
+					table.setFocus();
+				}
+			} else {
 				text.setFocus();
 			}
 			break;
@@ -595,6 +599,10 @@ public class TableCombo extends Composite {
 			internalLayout(false, true);
 			break;
 		}
+	}
+
+	private boolean isWindows() {
+		return System.getProperty("os.name").indexOf("indows") != -1;
 	}
 
 	/**


### PR DESCRIPTION
TableComboViewer dropdown not closed automatically on mouse click on the dialog area => this bug is side effect of a Linux-only bug