### PR TITLE
Only fire a selection event when the value changes

### DIFF
--- a/widgets/nebulaslider/org.eclipse.nebula.widgets.nebulaslider/src/org/eclipse/nebula/widgets/opal/nebulaslider/NebulaSlider.java
+++ b/widgets/nebulaslider/org.eclipse.nebula.widgets.nebulaslider/src/org/eclipse/nebula/widgets/opal/nebulaslider/NebulaSlider.java
@@ -255,10 +255,13 @@ public class NebulaSlider extends Canvas {
 
 			// Update value
 			final float ratio = (float) xPosition / originalWidth;
-			value = (int) Math.floor(ratio * (maximum - minimum));
-
-			SelectionListenerUtil.fireSelectionListeners(this,e);
+			int value = (int)Math.floor(ratio * (maximum - minimum));
+			if(this.value != value) {
+				this.value = value;
+				SelectionListenerUtil.fireSelectionListeners(this, e);
+			}
 			redraw();
+
 		});
 	}
 


### PR DESCRIPTION
Currently the NebulaSlider fires a selection event on each move even if the value has not change numerically.

This first checks if the value has actually changed before redraw/event firing.