### PR TITLE
Add support for the default selection to the slider

### DIFF
--- a/widgets/nebulaslider/org.eclipse.nebula.widgets.nebulaslider/src/org/eclipse/nebula/widgets/opal/nebulaslider/NebulaSlider.java
+++ b/widgets/nebulaslider/org.eclipse.nebula.widgets.nebulaslider/src/org/eclipse/nebula/widgets/opal/nebulaslider/NebulaSlider.java
@@ -51,6 +51,8 @@ public class NebulaSlider extends Canvas {
 
 	private IntFunction<String> format;
 
+	private int movingValue;
+
 	/**
 	 * Constructs a new instance of this class given its parent and a style value
 	 * describing its behavior and appearance.
@@ -229,12 +231,16 @@ public class NebulaSlider extends Canvas {
 				return;
 			}
 			moving = true;
+			movingValue = value;
 			mouseDeltaX = xPosition - e.x;
 		});
 
 		addListener(SWT.MouseUp, e -> {
 			moving = false;
 			mouseDeltaX = 0;
+			if(movingValue != value) {
+				SelectionListenerUtil.fireDefaultSelectionListeners(this, e);
+			}
 			redraw();
 		});
 

--- a/widgets/opal/commons/org.eclipse.nebula.widgets.opal.commons/src/org/eclipse/nebula/widgets/opal/commons/SelectionListenerUtil.java
+++ b/widgets/opal/commons/org.eclipse.nebula.widgets.opal.commons/src/org/eclipse/nebula/widgets/opal/commons/SelectionListenerUtil.java
@@ -65,7 +65,23 @@ public class SelectionListenerUtil {
 	 * @return true if the selection could be changed, false otherwise
 	 */
 	public static boolean fireSelectionListeners(final Control control, final Event sourceEvent) {
-		for (final Listener listener : control.getListeners(SWT.Selection)) {
+		return fireSelectionListenersEvent(control, sourceEvent, SWT.Selection);
+	}
+	
+	/**
+	 * Fire the default selection listeners of a given control
+	 *
+	 * @param control the control that fires the event
+	 * @param sourceEvent mouse event
+	 * @return true if the selection could be changed, false otherwise
+	 */
+	public static boolean fireDefaultSelectionListeners(final Control control, final Event sourceEvent) {
+		return fireSelectionListenersEvent(control, sourceEvent, SWT.DefaultSelection);
+	}
+
+	private static boolean fireSelectionListenersEvent(final Control control, final Event sourceEvent, int type) {
+		Listener[] listeners = control.getListeners(SWT.Selection);
+		for(final Listener listener : listeners) {
 			final Event event = new Event();
 
 			event.button = sourceEvent==null?1:sourceEvent.button;
@@ -76,7 +92,7 @@ public class SelectionListenerUtil {
 			event.time = sourceEvent == null ? 0 : sourceEvent.time;
 			event.x = sourceEvent == null ? 0 : sourceEvent.x;
 			event.y = sourceEvent == null ? 0 : sourceEvent.y;
-			event.type = SWT.Selection;
+			event.type = type;
 
 			listener.handleEvent(event);
 			if (!event.doit) {


### PR DESCRIPTION
Currently the slider fires an update event on each change, but this can be not desired e.g because changing the value might be an expensive operation, or even the user chooses the same value in the end.

This now captures the current value on mouse down and if it has changed on mouseup fires a default selection event. This way a user of the slider can always decide what approach works best or even combine the different approaches. For example one can use the fast changing value to update ui-elements and the default selection to persist the value to disk/database/preferences/...