### PR TITLE
Replace usage of internal SWT TypedListener and SWTEventListener

### DIFF
--- a/widgets/calendarcombo/org.eclipse.nebula.widgets.calendarcombo/META-INF/MANIFEST.MF
+++ b/widgets/calendarcombo/org.eclipse.nebula.widgets.calendarcombo/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Nebula Calendar Combo Widget - Incubating
 Bundle-SymbolicName: org.eclipse.nebula.widgets.calendarcombo
 Bundle-Version: 1.0.0.qualifier
-Require-Bundle: org.eclipse.swt
+Require-Bundle: org.eclipse.swt;bundle-version="[3.126.0,4.0.0)"
 Export-Package: org.eclipse.nebula.widgets.calendarcombo
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Vendor: Eclipse Nebula

--- a/widgets/calendarcombo/org.eclipse.nebula.widgets.calendarcombo/src/org/eclipse/nebula/widgets/calendarcombo/CustomCombo.java
+++ b/widgets/calendarcombo/org.eclipse.nebula.widgets.calendarcombo/src/org/eclipse/nebula/widgets/calendarcombo/CustomCombo.java
@@ -30,7 +30,6 @@ import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
-import org.eclipse.swt.widgets.TypedListener;
 import org.eclipse.swt.widgets.Widget;
 
 /**
@@ -259,11 +258,7 @@ public class CustomCombo extends Composite {
 	 * @see #removeModifyListener
 	 */
 	public void addModifyListener(ModifyListener listener) {
-		checkWidget();
-		if (listener == null)
-			SWT.error(SWT.ERROR_NULL_ARGUMENT);
-		TypedListener typedListener = new TypedListener(listener);
-		addListener(SWT.Modify, typedListener);
+		addTypedListener(listener, SWT.Modify);
 	}
 
 	/**
@@ -294,12 +289,7 @@ public class CustomCombo extends Composite {
 	 * @see SelectionEvent
 	 */
 	public void addSelectionListener(SelectionListener listener) {
-		checkWidget();
-		if (listener == null)
-			SWT.error(SWT.ERROR_NULL_ARGUMENT);
-		TypedListener typedListener = new TypedListener(listener);
-		addListener(SWT.Selection, typedListener);
-		addListener(SWT.DefaultSelection, typedListener);
+		addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 	}
 
 	/**
@@ -325,11 +315,7 @@ public class CustomCombo extends Composite {
 	 * @since 3.3
 	 */
 	public void addVerifyListener(VerifyListener listener) {
-		checkWidget();
-		if (listener == null)
-			SWT.error(SWT.ERROR_NULL_ARGUMENT);
-		TypedListener typedListener = new TypedListener(listener);
-		addListener(SWT.Verify, typedListener);
+		addTypedListener(listener, SWT.Verify);
 	}
 
 	void arrowEvent(Event event) {
@@ -1417,10 +1403,7 @@ public class CustomCombo extends Composite {
 	 * @see #addModifyListener
 	 */
 	public void removeModifyListener(ModifyListener listener) {
-		checkWidget();
-		if (listener == null)
-			SWT.error(SWT.ERROR_NULL_ARGUMENT);
-		removeListener(SWT.Modify, listener);
+		removeTypedListener(SWT.Modify, listener);
 	}
 
 	/**
@@ -1442,11 +1425,8 @@ public class CustomCombo extends Composite {
 	 * @see #addSelectionListener
 	 */
 	public void removeSelectionListener(SelectionListener listener) {
-		checkWidget();
-		if (listener == null)
-			SWT.error(SWT.ERROR_NULL_ARGUMENT);
-		removeListener(SWT.Selection, listener);
-		removeListener(SWT.DefaultSelection, listener);
+		removeTypedListener(SWT.Selection, listener);
+		removeTypedListener(SWT.DefaultSelection, listener);
 	}
 
 	/**
@@ -1470,10 +1450,7 @@ public class CustomCombo extends Composite {
 	 * @since 3.3
 	 */
 	public void removeVerifyListener(VerifyListener listener) {
-		checkWidget();
-		if (listener == null)
-			SWT.error(SWT.ERROR_NULL_ARGUMENT);
-		removeListener(SWT.Verify, listener);
+		removeTypedListener(SWT.Verify, listener);
 	}
 
 	/**

--- a/widgets/carousel/org.eclipse.nebula.widgets.carousel/META-INF/MANIFEST.MF
+++ b/widgets/carousel/org.eclipse.nebula.widgets.carousel/META-INF/MANIFEST.MF
@@ -7,5 +7,5 @@ Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.eclipse.nebula.widgets.carousel
 Require-Bundle: org.eclipse.nebula.widgets.opal.commons;visibility:=reexport,
- org.eclipse.swt
+ org.eclipse.swt;bundle-version="[3.126.0,4.0.0)"
 Automatic-Module-Name: org.eclipse.nebula.widgets.carousel

--- a/widgets/carousel/org.eclipse.nebula.widgets.carousel/src/org/eclipse/nebula/widgets/carousel/Carousel.java
+++ b/widgets/carousel/org.eclipse.nebula.widgets.carousel/src/org/eclipse/nebula/widgets/carousel/Carousel.java
@@ -165,8 +165,7 @@ public class Carousel extends Composite {
 	 * @see SelectionEvent
 	 */
 	public void addSelectionListener(final SelectionListener listener) {
-		checkWidget();
-		SelectionListenerUtil.addSelectionListener(this, listener);
+		addTypedListener(listener, SWT.Selection);
 	}
 
 	/**
@@ -219,8 +218,7 @@ public class Carousel extends Composite {
 	 * @see #addSelectionListener
 	 */
 	public void removeSelectionListener(final SelectionListener listener) {
-		checkWidget();
-		SelectionListenerUtil.removeSelectionListener(this, listener);
+		removeTypedListener(SWT.Selection, listener);
 	}
 
 	// ---- Getters & Setters

--- a/widgets/cdatetime/org.eclipse.nebula.widgets.cdatetime/META-INF/MANIFEST.MF
+++ b/widgets/cdatetime/org.eclipse.nebula.widgets.cdatetime/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.core.runtime,
- org.eclipse.swt,
+ org.eclipse.swt;bundle-version="[3.126.0,4.0.0)",
  org.eclipse.nebula.cwt;bundle-version="0.9.0";visibility:=reexport
 Export-Package: org.eclipse.nebula.widgets.cdatetime
 Automatic-Module-Name: org.eclipse.nebula.widgets.cdatetime

--- a/widgets/cdatetime/org.eclipse.nebula.widgets.cdatetime/src/org/eclipse/nebula/widgets/cdatetime/CDateTime.java
+++ b/widgets/cdatetime/org.eclipse.nebula.widgets.cdatetime/src/org/eclipse/nebula/widgets/cdatetime/CDateTime.java
@@ -65,7 +65,6 @@ import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Spinner;
 import org.eclipse.swt.widgets.Text;
-import org.eclipse.swt.widgets.TypedListener;
 
 /**
  * The CDateTime provides both textual and graphical means selecting a
@@ -425,9 +424,7 @@ public class CDateTime extends BaseCombo {
 	 */
 	public void addSelectionListener(SelectionListener listener) {
 		if (listener != null) {
-			TypedListener typedListener = new TypedListener(listener);
-			addListener(SWT.Selection, typedListener);
-			addListener(SWT.DefaultSelection, typedListener);
+			addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 		}
 	}
 
@@ -1527,9 +1524,8 @@ public class CDateTime extends BaseCombo {
 	 */
 	public void removeSelectionListener(SelectionListener listener) {
 		if (listener != null) {
-			TypedListener l = new TypedListener(listener);
-			removeListener(SWT.Selection, l);
-			removeListener(SWT.DefaultSelection, l);
+			removeTypedListener(SWT.Selection, listener);
+			removeTypedListener(SWT.DefaultSelection, listener);
 		}
 	}
 

--- a/widgets/chips/org.eclipse.nebula.widgets.chips/META-INF/MANIFEST.MF
+++ b/widgets/chips/org.eclipse.nebula.widgets.chips/META-INF/MANIFEST.MF
@@ -7,5 +7,5 @@ Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.eclipse.nebula.widgets.chips
 Require-Bundle: org.eclipse.nebula.widgets.opal.commons;visibility:=reexport,
- org.eclipse.swt
+ org.eclipse.swt;bundle-version="[3.126.0,4.0.0)"
 Automatic-Module-Name: org.eclipse.nebula.widgets.chips

--- a/widgets/chips/org.eclipse.nebula.widgets.chips/src/org/eclipse/nebula/widgets/chips/Chips.java
+++ b/widgets/chips/org.eclipse.nebula.widgets.chips/src/org/eclipse/nebula/widgets/chips/Chips.java
@@ -411,8 +411,7 @@ public class Chips extends Canvas {
 	 * @see SelectionEvent
 	 */
 	public void addSelectionListener(final SelectionListener listener) {
-		checkWidget();
-		SelectionListenerUtil.addSelectionListener(this, listener);
+		addTypedListener(listener, SWT.Selection);
 	}
 
 	/**
@@ -466,8 +465,7 @@ public class Chips extends Canvas {
 	 * @see #addSelectionListener
 	 */
 	public void removeSelectionListener(final SelectionListener listener) {
-		checkWidget();
-		SelectionListenerUtil.removeSelectionListener(this, listener);
+		removeTypedListener(SWT.Selection, listener);
 	}
 
 	// ---- Getters & Setters

--- a/widgets/chips/org.eclipse.nebula.widgets.chips/src/org/eclipse/nebula/widgets/chips/CloseListener.java
+++ b/widgets/chips/org.eclipse.nebula.widgets.chips/src/org/eclipse/nebula/widgets/chips/CloseListener.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.nebula.widgets.chips;
 
-import org.eclipse.swt.internal.SWTEventListener;
+import java.util.EventListener;
 
 /**
  * Classes which implement this interface provide methods
@@ -28,9 +28,8 @@ import org.eclipse.swt.internal.SWTEventListener;
  *
  * @see CloseEvent
  */
-@SuppressWarnings("restriction")
 @FunctionalInterface
-public interface CloseListener extends SWTEventListener {
+public interface CloseListener extends EventListener {
 	/**
 	 * Sent when a Chips widget is closed.
 	 *

--- a/widgets/ctree/org.eclipse.nebula.widgets.ctree/META-INF/MANIFEST.MF
+++ b/widgets/ctree/org.eclipse.nebula.widgets.ctree/META-INF/MANIFEST.MF
@@ -5,6 +5,6 @@ Bundle-SymbolicName: org.eclipse.nebula.widgets.ctree
 Bundle-Version: 0.8.0
 Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
-Require-Bundle: org.eclipse.swt
+Require-Bundle: org.eclipse.swt;bundle-version="[3.126.0,4.0.0)"
 Export-Package: org.eclipse.nebula.widgets.ctree
 Automatic-Module-Name: org.eclipse.nebula.widgets.ctree

--- a/widgets/ctree/org.eclipse.nebula.widgets.ctree/src/org/eclipse/nebula/widgets/ctree/CTree.java
+++ b/widgets/ctree/org.eclipse.nebula.widgets.ctree/src/org/eclipse/nebula/widgets/ctree/CTree.java
@@ -43,7 +43,6 @@ import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.ScrollBar;
 import org.eclipse.swt.widgets.Table;
-import org.eclipse.swt.widgets.TypedListener;
 import org.eclipse.swt.widgets.Widget;
 
 
@@ -389,18 +388,14 @@ public class CTree extends Composite implements Listener {
 	public void addSelectionListener(SelectionListener listener) {
 		checkWidget();
 		if (listener != null) {
-			TypedListener typedListener = new TypedListener(listener);
-			addListener(SWT.Selection, typedListener);
-			addListener(SWT.DefaultSelection, typedListener);
+			addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 		}
 	}
 
 	public void addTreeListener(TreeListener listener) {
 		checkWidget ();
 		if(listener != null) {
-			TypedListener typedListener = new TypedListener (listener);
-			addListener (SWT.Collapse, typedListener);
-			addListener (SWT.Expand, typedListener);
+			addTypedListener(listener, SWT.Collapse, SWT.Expand);
 		}
 	}
 
@@ -1367,16 +1362,16 @@ public class CTree extends Composite implements Listener {
 	public void removeSelectionListener(SelectionListener listener) {
 		checkWidget();
 		if (listener != null) {
-			removeListener(SWT.Selection, listener);
-			removeListener(SWT.DefaultSelection, listener);
+			removeTypedListener(SWT.Selection, listener);
+			removeTypedListener(SWT.DefaultSelection, listener);
 		}
 	}
 
 	public void removeTreeListener(TreeListener listener) {
 		checkWidget ();
 		if(listener != null) {
-			removeListener(SWT.Collapse, listener);
-			removeListener(SWT.Expand, listener);
+			removeTypedListener(SWT.Collapse, listener);
+			removeTypedListener(SWT.Expand, listener);
 		}
 	}
 	

--- a/widgets/ctreecombo/org.eclipse.nebula.widgets.ctreecombo/META-INF/MANIFEST.MF
+++ b/widgets/ctreecombo/org.eclipse.nebula.widgets.ctreecombo/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.eclipse.nebula.widgets.ctreecombo
 Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
-Require-Bundle: org.eclipse.swt,
+Require-Bundle: org.eclipse.swt;bundle-version="[3.126.0,4.0.0)",
  org.eclipse.jface,
  org.eclipse.core.runtime;bundle-version="3.13.0",
  org.eclipse.core.databinding.observable

--- a/widgets/ctreecombo/org.eclipse.nebula.widgets.ctreecombo/src/org/eclipse/nebula/widgets/ctreecombo/CTreeCombo.java
+++ b/widgets/ctreecombo/org.eclipse.nebula.widgets.ctreecombo/src/org/eclipse/nebula/widgets/ctreecombo/CTreeCombo.java
@@ -49,7 +49,6 @@ import org.eclipse.swt.widgets.Text;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.TreeColumn;
 import org.eclipse.swt.widgets.TreeItem;
-import org.eclipse.swt.widgets.TypedListener;
 import org.eclipse.swt.widgets.Widget;
 
 public class CTreeCombo extends Composite {
@@ -240,14 +239,7 @@ public class CTreeCombo extends Composite {
 	 * @see SelectionEvent
 	 */
 	public void addSelectionListener(final SelectionListener listener) {
-		checkWidget();
-		if (listener == null) {
-			SWT.error(SWT.ERROR_NULL_ARGUMENT);
-		}
-
-		final TypedListener typedListener = new TypedListener(listener);
-		addListener(SWT.Selection, typedListener);
-		addListener(SWT.DefaultSelection, typedListener);
+		addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 	}
 
 	/**
@@ -1125,12 +1117,8 @@ public class CTreeCombo extends Composite {
 	 * @see #addSelectionListener
 	 */
 	public void removeSelectionListener(final SelectionListener listener) {
-		checkWidget();
-		if (listener == null) {
-			SWT.error(SWT.ERROR_NULL_ARGUMENT);
-		}
-		removeListener(SWT.Selection, listener);
-		removeListener(SWT.DefaultSelection, listener);
+		removeTypedListener(SWT.Selection, listener);
+		removeTypedListener(SWT.DefaultSelection, listener);
 	}
 
 	/**

--- a/widgets/datechooser/org.eclipse.nebula.widgets.datechooser/META-INF/MANIFEST.MF
+++ b/widgets/datechooser/org.eclipse.nebula.widgets.datechooser/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Export-Package: org.eclipse.nebula.widgets.datechooser
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Vendor: Eclipse Nebula
 Import-Package: org.eclipse.jface.layout,
- org.eclipse.swt,
+ org.eclipse.swt;bundle-version="[3.126.0,4.0.0)",
  org.eclipse.swt.events,
  org.eclipse.swt.graphics,
  org.eclipse.swt.internal,

--- a/widgets/datechooser/org.eclipse.nebula.widgets.datechooser/src/org/eclipse/nebula/widgets/datechooser/AbstractCombo.java
+++ b/widgets/datechooser/org.eclipse.nebula.widgets.datechooser/src/org/eclipse/nebula/widgets/datechooser/AbstractCombo.java
@@ -36,7 +36,6 @@ import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
-import org.eclipse.swt.widgets.TypedListener;
 
 /**
  * Abstract class for combo widgets composed of a <code>Text</code>, a
@@ -201,11 +200,7 @@ public abstract class AbstractCombo extends Composite {
 	 * @see #removeModifyListener
 	 */
 	public void addModifyListener(ModifyListener listener) {
-		checkWidget();
-		if (listener == null)
-			SWT.error(SWT.ERROR_NULL_ARGUMENT);
-		TypedListener typedListener = new TypedListener(listener);
-		addListener(SWT.Modify, typedListener);
+		addTypedListener(listener, SWT.Modify);
 	}
 
 	/**
@@ -233,12 +228,7 @@ public abstract class AbstractCombo extends Composite {
 	 * @see SelectionEvent
 	 */
 	public void addSelectionListener(SelectionListener listener) {
-		checkWidget();
-		if (listener == null)
-			SWT.error(SWT.ERROR_NULL_ARGUMENT);
-		TypedListener typedListener = new TypedListener(listener);
-		addListener(SWT.Selection, typedListener);
-		addListener(SWT.DefaultSelection, typedListener);
+		addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 	}
 
 	/**
@@ -261,11 +251,7 @@ public abstract class AbstractCombo extends Composite {
 	 * @see #removeVerifyListener
 	 */
 	public void addVerifyListener(VerifyListener listener) {
-		checkWidget();
-		if (listener == null)
-			SWT.error(SWT.ERROR_NULL_ARGUMENT);
-		TypedListener typedListener = new TypedListener(listener);
-		addListener(SWT.Verify, typedListener);
+		addTypedListener(listener, SWT.Verify);
 	}
 
 	/**
@@ -832,10 +818,7 @@ public abstract class AbstractCombo extends Composite {
 	 * @see #addModifyListener
 	 */
 	public void removeModifyListener(ModifyListener listener) {
-		checkWidget();
-		if (listener == null)
-			SWT.error(SWT.ERROR_NULL_ARGUMENT);
-		removeListener(SWT.Modify, listener);
+		removeTypedListener(SWT.Modify, listener);
 	}
 
 	/**
@@ -856,11 +839,8 @@ public abstract class AbstractCombo extends Composite {
 	 * @see #addSelectionListener
 	 */
 	public void removeSelectionListener(SelectionListener listener) {
-		checkWidget();
-		if (listener == null)
-			SWT.error(SWT.ERROR_NULL_ARGUMENT);
-		removeListener(SWT.Selection, listener);
-		removeListener(SWT.DefaultSelection, listener);
+		removeTypedListener(SWT.Selection, listener);
+		removeTypedListener(SWT.DefaultSelection, listener);
 	}
 
 	/**
@@ -881,10 +861,7 @@ public abstract class AbstractCombo extends Composite {
 	 * @see #addVerifyListener
 	 */
 	public void removeVerifyListener(VerifyListener listener) {
-		checkWidget();
-		if (listener == null)
-			SWT.error(SWT.ERROR_NULL_ARGUMENT);
-		removeListener(SWT.Verify, listener);
+		removeTypedListener(SWT.Verify, listener);
 	}
 
 	/**

--- a/widgets/datechooser/org.eclipse.nebula.widgets.datechooser/src/org/eclipse/nebula/widgets/datechooser/DateChooser.java
+++ b/widgets/datechooser/org.eclipse.nebula.widgets.datechooser/src/org/eclipse/nebula/widgets/datechooser/DateChooser.java
@@ -47,7 +47,6 @@ import org.eclipse.swt.widgets.Layout;
 import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.MenuItem;
-import org.eclipse.swt.widgets.TypedListener;
 
 /**
  * Calendar widget. Presents the monthly view of a calendar for date picking.
@@ -356,12 +355,7 @@ public class DateChooser extends Composite {
 	 * @see #removeSelectionListener
 	 */
 	public void addSelectionListener(SelectionListener lsnr) {
-		checkWidget();
-		if (lsnr == null) {
-			SWT.error(SWT.ERROR_NULL_ARGUMENT);
-		}
-		final TypedListener typedListener = new TypedListener(lsnr);
-		addListener(SWT.Selection, typedListener);
+		addTypedListener(lsnr, SWT.Selection);
 	}
 
 	/**
@@ -1106,11 +1100,7 @@ public class DateChooser extends Composite {
 	 * @see #addSelectionListener
 	 */
 	public void removeSelectionListener(SelectionListener lsnr) {
-		checkWidget();
-		if (lsnr == null) {
-			SWT.error(SWT.ERROR_NULL_ARGUMENT);
-		}
-		removeListener(SWT.Selection, lsnr);
+		removeTypedListener(SWT.Selection, lsnr);
 	}
 
 	/**

--- a/widgets/gallery/org.eclipse.nebula.widgets.gallery/META-INF/MANIFEST.MF
+++ b/widgets/gallery/org.eclipse.nebula.widgets.gallery/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Nebula Gallery Widget
 Bundle-SymbolicName: org.eclipse.nebula.widgets.gallery
 Bundle-Version: 1.0.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
-Require-Bundle: org.eclipse.swt,
+Require-Bundle: org.eclipse.swt;bundle-version="[3.126.0,4.0.0)",
  org.eclipse.jface;resolution:=optional
 Export-Package: org.eclipse.nebula.animation,
  org.eclipse.nebula.animation.effects,

--- a/widgets/gallery/org.eclipse.nebula.widgets.gallery/src/org/eclipse/nebula/widgets/gallery/Gallery.java
+++ b/widgets/gallery/org.eclipse.nebula.widgets.gallery/src/org/eclipse/nebula/widgets/gallery/Gallery.java
@@ -33,7 +33,6 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Item;
 import org.eclipse.swt.widgets.ScrollBar;
-import org.eclipse.swt.widgets.TypedListener;
 
 /**
  * <p>
@@ -309,13 +308,7 @@ public class Gallery extends Canvas {
 	 * @see SelectionEvent
 	 */
 	public void addSelectionListener(SelectionListener listener) {
-		checkWidget();
-		if (listener == null)
-			SWT.error(SWT.ERROR_NULL_ARGUMENT);
-
-		TypedListener typedListener = new TypedListener(listener);
-		addListener(SWT.Selection, typedListener);
-		addListener(SWT.DefaultSelection, typedListener);
+		addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 	}
 
 	/**
@@ -341,9 +334,8 @@ public class Gallery extends Canvas {
 	 * @see #addSelectionListener(SelectionListener)
 	 */
 	public void removeSelectionListener(SelectionListener listener) {
-		checkWidget();
-		removeListener(SWT.Selection, listener);
-		removeListener(SWT.DefaultSelection, listener);
+		removeTypedListener(SWT.Selection, listener);
+		removeTypedListener(SWT.DefaultSelection, listener);
 	}
 
 	/**
@@ -353,8 +345,7 @@ public class Gallery extends Canvas {
 	 * @param listener
 	 */
 	public void removeTreeListener(SelectionListener listener) {
-		checkWidget();
-		removeListener(SWT.Expand, listener);
+		removeTypedListener(SWT.Expand, listener);
 	}
 
 	/**
@@ -365,10 +356,7 @@ public class Gallery extends Canvas {
 	 * @param listener
 	 */
 	public void addTreeListener(TreeListener listener) {
-		checkWidget();
-		if (listener == null)
-			SWT.error(SWT.ERROR_NULL_ARGUMENT);
-		addListener(SWT.Expand, new TypedListener(listener));
+		addTypedListener(listener, SWT.Expand);
 	}
 
 	/**

--- a/widgets/grid/org.eclipse.nebula.widgets.grid/META-INF/MANIFEST.MF
+++ b/widgets/grid/org.eclipse.nebula.widgets.grid/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Nebula Grid
 Bundle-SymbolicName: org.eclipse.nebula.widgets.grid
 Bundle-Version: 1.1.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
-Require-Bundle: org.eclipse.swt,
+Require-Bundle: org.eclipse.swt;bundle-version="[3.126.0,4.0.0)",
  org.eclipse.jface;resolution:=optional
 Export-Package: org.eclipse.nebula.jface.gridviewer,
  org.eclipse.nebula.jface.gridviewer.internal;x-internal:=true,

--- a/widgets/grid/org.eclipse.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/Grid.java
+++ b/widgets/grid/org.eclipse.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/Grid.java
@@ -82,7 +82,6 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.ScrollBar;
-import org.eclipse.swt.widgets.TypedListener;
 
 /**
  * The Grid widget is a spreadsheet/table component that offers features not
@@ -956,12 +955,7 @@ public class Grid extends Canvas {
 	 *             </ul>
 	 */
 	public void addSelectionListener(final SelectionListener listener) {
-		checkWidget();
-		if (listener == null) {
-			SWT.error(SWT.ERROR_NULL_ARGUMENT);
-		}
-		addListener(SWT.Selection, new TypedListener(listener));
-		addListener(SWT.DefaultSelection, new TypedListener(listener));
+		addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 	}
 
 	/**
@@ -987,13 +981,7 @@ public class Grid extends Canvas {
 	 * @see org.eclipse.swt.events.TreeEvent
 	 */
 	public void addTreeListener(final TreeListener listener) {
-		checkWidget();
-		if (listener == null) {
-			SWT.error(SWT.ERROR_NULL_ARGUMENT);
-		}
-
-		addListener(SWT.Expand, new TypedListener(listener));
-		addListener(SWT.Collapse, new TypedListener(listener));
+		addTypedListener(listener, SWT.Expand, SWT.Collapse);
 	}
 
 	/**
@@ -3273,9 +3261,8 @@ public class Grid extends Canvas {
 	 *             </ul>
 	 */
 	public void removeSelectionListener(final SelectionListener listener) {
-		checkWidget();
-		removeListener(SWT.Selection, listener);
-		removeListener(SWT.DefaultSelection, listener);
+		removeTypedListener(SWT.Selection, listener);
+		removeTypedListener(SWT.DefaultSelection, listener);
 	}
 
 	/**
@@ -3295,9 +3282,8 @@ public class Grid extends Canvas {
 	 *             </ul>
 	 */
 	public void removeTreeListener(final TreeListener listener) {
-		checkWidget();
-		removeListener(SWT.Expand, listener);
-		removeListener(SWT.Collapse, listener);
+		removeTypedListener(SWT.Expand, listener);
+		removeTypedListener(SWT.Collapse, listener);
 	}
 
 	/**

--- a/widgets/grid/org.eclipse.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/GridColumn.java
+++ b/widgets/grid/org.eclipse.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/GridColumn.java
@@ -37,7 +37,6 @@ import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Item;
-import org.eclipse.swt.widgets.TypedListener;
 
 /**
  * <p>
@@ -502,11 +501,7 @@ public class GridColumn extends Item {
 	 *             </ul>
 	 */
 	public void addSelectionListener(final SelectionListener listener) {
-		checkWidget();
-		if (listener == null) {
-			SWT.error(SWT.ERROR_NULL_ARGUMENT);
-		}
-		addListener(SWT.Selection, new TypedListener(listener));
+		addTypedListener(listener, SWT.Selection);
 	}
 
 	/**
@@ -526,8 +521,7 @@ public class GridColumn extends Item {
 	 *             </ul>
 	 */
 	public void removeSelectionListener(final SelectionListener listener) {
-		checkWidget();
-		this.removeListener(SWT.Selection, listener);
+		removeTypedListener(SWT.Selection, listener);
 	}
 
 	/**
@@ -814,13 +808,7 @@ public class GridColumn extends Item {
 	 *             </ul>
 	 */
 	public void addControlListener(final ControlListener listener) {
-		checkWidget();
-		if (listener == null) {
-			SWT.error(SWT.ERROR_NULL_ARGUMENT);
-		}
-		final TypedListener typedListener = new TypedListener(listener);
-		addListener(SWT.Resize, typedListener);
-		addListener(SWT.Move, typedListener);
+		addTypedListener(listener, SWT.Resize, SWT.Move);
 	}
 
 	/**
@@ -841,12 +829,8 @@ public class GridColumn extends Item {
 	 *             </ul>
 	 */
 	public void removeControlListener(final ControlListener listener) {
-		checkWidget();
-		if (listener == null) {
-			SWT.error(SWT.ERROR_NULL_ARGUMENT);
-		}
-		removeListener(SWT.Resize, listener);
-		removeListener(SWT.Move, listener);
+		removeTypedListener(SWT.Resize, listener);
+		removeTypedListener(SWT.Move, listener);
 	}
 
 	/**

--- a/widgets/grid/org.eclipse.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/GridColumnGroup.java
+++ b/widgets/grid/org.eclipse.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/GridColumnGroup.java
@@ -25,7 +25,6 @@ import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Item;
-import org.eclipse.swt.widgets.TypedListener;
 
 /**
  * <p>
@@ -122,11 +121,7 @@ public class GridColumnGroup extends Item
      * @see #removeTreeListener
      */
     public void addTreeListener(TreeListener listener) {
-        checkWidget ();
-        if (listener == null) SWT.error (SWT.ERROR_NULL_ARGUMENT);
-        TypedListener typedListener = new TypedListener (listener);
-        addListener (SWT.Expand, typedListener);
-        addListener (SWT.Collapse, typedListener);
+    	addTypedListener(listener, SWT.Expand, SWT.Collapse);
     }
 
     /**
@@ -147,10 +142,8 @@ public class GridColumnGroup extends Item
      * @see #addTreeListener
      */
     public void removeTreeListener(TreeListener listener) {
-        checkWidget ();
-        if (listener == null) SWT.error (SWT.ERROR_NULL_ARGUMENT);
-        removeListener (SWT.Expand, listener);
-        removeListener (SWT.Collapse, listener);
+        removeTypedListener(SWT.Expand, listener);
+        removeTypedListener(SWT.Collapse, listener);
     }
 
     /**

--- a/widgets/grid/org.eclipse.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/GridItem.java
+++ b/widgets/grid/org.eclipse.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/GridItem.java
@@ -30,7 +30,6 @@ import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Item;
-import org.eclipse.swt.widgets.TypedListener;
 
 /**
  * <p>
@@ -348,11 +347,7 @@ public class GridItem extends Item {
 	 *                </ul>
 	 */
 	public void addControlListener(ControlListener listener) {
-		checkWidget();
-		if (listener == null)
-			SWT.error(SWT.ERROR_NULL_ARGUMENT);
-		TypedListener typedListener = new TypedListener(listener);
-		addListener(SWT.Resize, typedListener);
+		addTypedListener(listener, SWT.Resize);
 	}
 
 	/**
@@ -375,10 +370,7 @@ public class GridItem extends Item {
 	 *                </ul>
 	 */
 	public void removeControlListener(ControlListener listener) {
-		checkWidget();
-		if (listener == null)
-			SWT.error(SWT.ERROR_NULL_ARGUMENT);
-		removeListener(SWT.Resize, listener);
+		removeTypedListener(SWT.Resize, listener);
 	}
 
 	/**

--- a/widgets/nebulaslider/org.eclipse.nebula.widgets.nebulaslider/META-INF/MANIFEST.MF
+++ b/widgets/nebulaslider/org.eclipse.nebula.widgets.nebulaslider/META-INF/MANIFEST.MF
@@ -6,6 +6,6 @@ Bundle-Version: 1.1.0.qualifier
 Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.nebula.widgets.opal.commons;bundle-version="1.0.0";visibility:=reexport,
- org.eclipse.swt
+ org.eclipse.swt;bundle-version="[3.126.0,4.0.0)"
 Export-Package: org.eclipse.nebula.widgets.opal.nebulaslider
 Automatic-Module-Name: org.eclipse.nebula.widgets.nebulaslider

--- a/widgets/nebulaslider/org.eclipse.nebula.widgets.nebulaslider/src/org/eclipse/nebula/widgets/opal/nebulaslider/NebulaSlider.java
+++ b/widgets/nebulaslider/org.eclipse.nebula.widgets.nebulaslider/src/org/eclipse/nebula/widgets/opal/nebulaslider/NebulaSlider.java
@@ -340,8 +340,7 @@ public class NebulaSlider extends Canvas {
 	 * @see SelectionEvent
 	 */
 	public void addSelectionListener(final SelectionListener listener) {
-		checkWidget();
-		SelectionListenerUtil.addSelectionListener(this, listener);
+		addTypedListener(listener, SWT.Selection);
 	}
 
 	/**
@@ -374,8 +373,7 @@ public class NebulaSlider extends Canvas {
 	 * @see #addSelectionListener
 	 */
 	public void removeSelectionListener(final SelectionListener listener) {
-		checkWidget();
-		SelectionListenerUtil.removeSelectionListener(this, listener);
+		removeTypedListener(SWT.Selection, listener);
 	}
 
 	// ----------------------- Getters & Setters

--- a/widgets/opal/checkboxgroup/org.eclipse.nebula.widgets.opal.checkboxgroup/META-INF/MANIFEST.MF
+++ b/widgets/opal/checkboxgroup/org.eclipse.nebula.widgets.opal.checkboxgroup/META-INF/MANIFEST.MF
@@ -6,6 +6,6 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.nebula.widgets.opal.commons;bundle-version="1.0.0";visibility:=reexport,
- org.eclipse.swt
+ org.eclipse.swt;bundle-version="[3.126.0,4.0.0)"
 Export-Package: org.eclipse.nebula.widgets.opal.checkboxgroup
 Automatic-Module-Name: org.eclipse.nebula.widgets.opal.checkboxgroup

--- a/widgets/opal/checkboxgroup/org.eclipse.nebula.widgets.opal.checkboxgroup/src/org/eclipse/nebula/widgets/opal/checkboxgroup/CheckBoxGroup.java
+++ b/widgets/opal/checkboxgroup/org.eclipse.nebula.widgets.opal.checkboxgroup/src/org/eclipse/nebula/widgets/opal/checkboxgroup/CheckBoxGroup.java
@@ -157,8 +157,7 @@ public class CheckBoxGroup extends Canvas implements PaintListener {
 	 * @see SelectionEvent
 	 */
 	public void addSelectionListener(final SelectionListener listener) {
-		checkWidget();
-		SelectionListenerUtil.addSelectionListener(this, listener);	
+		addTypedListener(listener, SWT.Selection);
 	}
 
 	/**
@@ -207,8 +206,7 @@ public class CheckBoxGroup extends Canvas implements PaintListener {
 	 * @see #addSelectionListener
 	 */
 	public void removeSelectionListener(final SelectionListener listener) {
-		checkWidget();
-		SelectionListenerUtil.removeSelectionListener(this, listener);
+		removeTypedListener(SWT.Selection, listener);
 	}
 
 	

--- a/widgets/opal/columnbrowser/org.eclipse.nebula.widgets.opal.columnbrowser/META-INF/MANIFEST.MF
+++ b/widgets/opal/columnbrowser/org.eclipse.nebula.widgets.opal.columnbrowser/META-INF/MANIFEST.MF
@@ -6,6 +6,6 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.nebula.widgets.opal.commons;bundle-version="1.0.0";visibility:=reexport,
- org.eclipse.swt
+ org.eclipse.swt;bundle-version="[3.126.0,4.0.0)"
 Export-Package: org.eclipse.nebula.widgets.opal.columnbrowser
 Automatic-Module-Name: org.eclipse.nebula.widgets.opal.columnbrowser

--- a/widgets/opal/columnbrowser/org.eclipse.nebula.widgets.opal.columnbrowser/src/org/eclipse/nebula/widgets/opal/columnbrowser/ColumnBrowserWidget.java
+++ b/widgets/opal/columnbrowser/org.eclipse.nebula.widgets.opal.columnbrowser/src/org/eclipse/nebula/widgets/opal/columnbrowser/ColumnBrowserWidget.java
@@ -325,8 +325,7 @@ public class ColumnBrowserWidget extends ScrolledComposite {
 	 * @see SelectionEvent
 	 */
 	public void addSelectionListener(final SelectionListener listener) {
-		checkWidget();
-		SelectionListenerUtil.addSelectionListener(this, listener);
+		addTypedListener(listener, SWT.Selection);
 	}
 
 	/**
@@ -405,8 +404,7 @@ public class ColumnBrowserWidget extends ScrolledComposite {
 	 * @see #addSelectionListener
 	 */
 	public void removeSelectionListener(final SelectionListener listener) {
-		checkWidget();
-		SelectionListenerUtil.removeSelectionListener(this, listener);
+		removeTypedListener(SWT.Selection, listener);
 	}
 
 	/**

--- a/widgets/opal/commons/org.eclipse.nebula.widgets.opal.commons/META-INF/MANIFEST.MF
+++ b/widgets/opal/commons/org.eclipse.nebula.widgets.opal.commons/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.equinox.common,
- org.eclipse.swt
+ org.eclipse.swt;bundle-version="[3.126.0,4.0.0)"
 Export-Package: org.eclipse.nebula.widgets.opal.commons,
  org.eclipse.nebula.widgets.opal.commons.resources
 Automatic-Module-Name: org.eclipse.nebula.widgets.opal.commons

--- a/widgets/opal/commons/org.eclipse.nebula.widgets.opal.commons/src/org/eclipse/nebula/widgets/opal/commons/SelectionListenerUtil.java
+++ b/widgets/opal/commons/org.eclipse.nebula.widgets.opal.commons/src/org/eclipse/nebula/widgets/opal/commons/SelectionListenerUtil.java
@@ -18,7 +18,6 @@ import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Listener;
-import org.eclipse.swt.widgets.TypedListener;
 
 public class SelectionListenerUtil {
 	/**
@@ -27,11 +26,12 @@ public class SelectionListenerUtil {
 	 * @param control control on which the selection listener is added
 	 * @param listener listener to add
 	 */
+	@Deprecated(forRemoval = true)
 	public static void addSelectionListener(final Control control, final SelectionListener listener) {
 		if (listener == null) {
 			SWT.error(SWT.ERROR_NULL_ARGUMENT);
 		}
-		TypedListener typedListener = new TypedListener(listener);
+		var typedListener = new org.eclipse.swt.widgets.TypedListener(listener);
 		control.addListener(SWT.Selection, typedListener);
 	}
 
@@ -41,20 +41,13 @@ public class SelectionListenerUtil {
 	 * @param control control on which the selection listener is removed
 	 * @param listener listener to remove
 	 */
+	@Deprecated(forRemoval = true)
 	public static void removeSelectionListener(final Control control, final SelectionListener listener) {
 		if (listener == null) {
 			SWT.error(SWT.ERROR_NULL_ARGUMENT);
 		}
-		final Listener[] listeners = control.getListeners(SWT.Selection);
-		for (Listener l : listeners) {
-			if (l instanceof TypedListener) {
-				TypedListener typedListener = (TypedListener) l;
-				if (typedListener.getEventListener() == listener) {
-					ReflectionUtils.callMethod(control, "removeListener", SWT.Selection, ((TypedListener) l).getEventListener());
-					return;
-				}
-			}
-		}
+		control.getTypedListeners(SWT.Selection, SelectionListener.class)
+				.forEach(l -> ReflectionUtils.callMethod(control, "removeListener", SWT.Selection, l));
 	}
 
 	/**

--- a/widgets/opal/duallist/org.eclipse.nebula.widgets.opal.duallist/META-INF/MANIFEST.MF
+++ b/widgets/opal/duallist/org.eclipse.nebula.widgets.opal.duallist/META-INF/MANIFEST.MF
@@ -6,6 +6,6 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.nebula.widgets.opal.commons;bundle-version="1.0.0";visibility:=reexport,
- org.eclipse.swt
+ org.eclipse.swt;bundle-version="[3.126.0,4.0.0)"
 Export-Package: org.eclipse.nebula.widgets.opal.duallist
 Automatic-Module-Name: org.eclipse.nebula.widgets.opal.duallist

--- a/widgets/opal/duallist/org.eclipse.nebula.widgets.opal.duallist/src/org/eclipse/nebula/widgets/opal/duallist/DualList.java
+++ b/widgets/opal/duallist/org.eclipse.nebula.widgets.opal.duallist/src/org/eclipse/nebula/widgets/opal/duallist/DualList.java
@@ -306,11 +306,7 @@ public class DualList extends Composite {
 	 * @see SelectionEvent
 	 */
 	public void addSelectionListener(final SelectionListener listener) {
-		checkWidget();
-		if (listener == null) {
-			SWT.error(SWT.ERROR_NULL_ARGUMENT);
-		}
-		SelectionListenerUtil.addSelectionListener(this, listener);
+		addTypedListener(listener, SWT.Selection);
 	}
 
 	/**
@@ -335,8 +331,7 @@ public class DualList extends Composite {
 	 * @see #addSelectionListener
 	 */
 	public void removeSelectionListener(final SelectionListener listener) {
-		checkWidget();
-		SelectionListenerUtil.removeSelectionListener(this, listener);
+		removeTypedListener(SWT.Selection, listener);
 	}
 
 	/**

--- a/widgets/opal/duallist/org.eclipse.nebula.widgets.opal.duallist/src/org/eclipse/nebula/widgets/opal/duallist/SelectionChangeListener.java
+++ b/widgets/opal/duallist/org.eclipse.nebula.widgets.opal.duallist/src/org/eclipse/nebula/widgets/opal/duallist/SelectionChangeListener.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.nebula.widgets.opal.duallist;
 
-import org.eclipse.swt.internal.SWTEventListener;
+import java.util.EventListener;
 
 /**
  * Classes which implement this interface provide methods that deal with the
@@ -27,9 +27,8 @@ import org.eclipse.swt.internal.SWTEventListener;
  *
  * @see SelectionChangeEvent
  */
-@SuppressWarnings("restriction")
 @FunctionalInterface
-public interface SelectionChangeListener extends SWTEventListener {
+public interface SelectionChangeListener extends EventListener {
 
 	/**
 	 * Sent when selection occurs in the control.

--- a/widgets/opal/horizontalspinner/org.eclipse.nebula.widgets.opal.horizontalspinner/META-INF/MANIFEST.MF
+++ b/widgets/opal/horizontalspinner/org.eclipse.nebula.widgets.opal.horizontalspinner/META-INF/MANIFEST.MF
@@ -6,6 +6,6 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.nebula.widgets.opal.commons;bundle-version="1.0.0";visibility:=reexport,
- org.eclipse.swt
+ org.eclipse.swt;bundle-version="[3.126.0,4.0.0)"
 Export-Package: org.eclipse.nebula.widgets.opal.horizontalspinner
 Automatic-Module-Name: org.eclipse.nebula.widgets.opal.horizontalspinner

--- a/widgets/opal/horizontalspinner/org.eclipse.nebula.widgets.opal.horizontalspinner/src/org/eclipse/nebula/widgets/opal/horizontalspinner/HorizontalSpinner.java
+++ b/widgets/opal/horizontalspinner/org.eclipse.nebula.widgets.opal.horizontalspinner/src/org/eclipse/nebula/widgets/opal/horizontalspinner/HorizontalSpinner.java
@@ -363,8 +363,7 @@ public class HorizontalSpinner extends Composite {
 	 * @see SelectionEvent
 	 */
 	public void addSelectionListener(final SelectionListener listener) {
-		checkWidget();
-		SelectionListenerUtil.addSelectionListener(this, listener);
+		addTypedListener(listener, SWT.Selection);
 	}
 
 	/**
@@ -627,8 +626,7 @@ public class HorizontalSpinner extends Composite {
 	 * @see #addSelectionListener
 	 */
 	public void removeSelectionListener(final SelectionListener listener) {
-		checkWidget();
-		SelectionListenerUtil.removeSelectionListener(this, listener);
+		removeTypedListener(SWT.Selection, listener);
 	}
 
 	/**

--- a/widgets/opal/launcher/org.eclipse.nebula.widgets.opal.launcher/META-INF/MANIFEST.MF
+++ b/widgets/opal/launcher/org.eclipse.nebula.widgets.opal.launcher/META-INF/MANIFEST.MF
@@ -6,6 +6,6 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.nebula.widgets.opal.commons;bundle-version="1.0.0";visibility:=reexport,
- org.eclipse.swt
+ org.eclipse.swt;bundle-version="[3.126.0,4.0.0)"
 Export-Package:  org.eclipse.nebula.widgets.opal.launcher
 Automatic-Module-Name: org.eclipse.nebula.widgets.opal.launcher

--- a/widgets/opal/launcher/org.eclipse.nebula.widgets.opal.launcher/src/org/eclipse/nebula/widgets/opal/launcher/Launcher.java
+++ b/widgets/opal/launcher/org.eclipse.nebula.widgets.opal.launcher/src/org/eclipse/nebula/widgets/opal/launcher/Launcher.java
@@ -152,8 +152,7 @@ public class Launcher extends Composite {
 	 * @see SelectionEvent
 	 */
 	public void addSelectionListener(final SelectionListener listener) {
-		checkWidget();
-		SelectionListenerUtil.addSelectionListener(this, listener);
+		addTypedListener(listener, SWT.Selection);
 	}
 
 	/**
@@ -395,11 +394,7 @@ public class Launcher extends Composite {
 	 * @see #addSelectionListener
 	 */
 	public void removeSelectionListener(final SelectionListener listener) {
-		checkWidget();
-		if (listener == null) {
-			SWT.error(SWT.ERROR_NULL_ARGUMENT);
-		}
-		SelectionListenerUtil.removeSelectionListener(this, listener);
+		removeTypedListener(SWT.Selection, listener);
 	}
 
 	/**

--- a/widgets/opal/rangeslider/org.eclipse.nebula.widgets.opal.rangeslider/META-INF/MANIFEST.MF
+++ b/widgets/opal/rangeslider/org.eclipse.nebula.widgets.opal.rangeslider/META-INF/MANIFEST.MF
@@ -6,6 +6,6 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.nebula.widgets.opal.commons;bundle-version="1.0.0";visibility:=reexport,
- org.eclipse.swt
+ org.eclipse.swt;bundle-version="[3.126.0,4.0.0)"
 Export-Package: org.eclipse.nebula.widgets.opal.rangeslider
 Automatic-Module-Name: org.eclipse.nebula.widgets.opal.rangeslider

--- a/widgets/opal/rangeslider/org.eclipse.nebula.widgets.opal.rangeslider/src/org/eclipse/nebula/widgets/opal/rangeslider/RangeSlider.java
+++ b/widgets/opal/rangeslider/org.eclipse.nebula.widgets.opal.rangeslider/src/org/eclipse/nebula/widgets/opal/rangeslider/RangeSlider.java
@@ -1126,8 +1126,7 @@ public class RangeSlider extends Canvas {
 	 * @see #removeSelectionListener
 	 */
 	public void addSelectionListener(final SelectionListener listener) {
-		checkWidget();
-		SelectionListenerUtil.addSelectionListener(this, listener);
+		addTypedListener(listener, SWT.Selection);
 	}
 
 	/**
@@ -1320,8 +1319,7 @@ public class RangeSlider extends Canvas {
 	 * @see #addSelectionListener
 	 */
 	public void removeSelectionListener(final SelectionListener listener) {
-		checkWidget();
-		SelectionListenerUtil.removeSelectionListener(this, listener);
+		removeTypedListener(SWT.Selection, listener);
 	}
 
 	/**

--- a/widgets/opal/starrating/org.eclipse.nebula.widgets.opal.starrating/META-INF/MANIFEST.MF
+++ b/widgets/opal/starrating/org.eclipse.nebula.widgets.opal.starrating/META-INF/MANIFEST.MF
@@ -6,6 +6,6 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.nebula.widgets.opal.commons;bundle-version="1.0.0";visibility:=reexport,
- org.eclipse.swt
+ org.eclipse.swt;bundle-version="[3.126.0,4.0.0)"
 Export-Package: org.eclipse.nebula.widgets.opal.starrating
 Automatic-Module-Name: org.eclipse.nebula.widgets.opal.starrating

--- a/widgets/opal/starrating/org.eclipse.nebula.widgets.opal.starrating/src/org/eclipse/nebula/widgets/opal/starrating/StarRating.java
+++ b/widgets/opal/starrating/org.eclipse.nebula.widgets.opal.starrating/src/org/eclipse/nebula/widgets/opal/starrating/StarRating.java
@@ -222,8 +222,7 @@ public class StarRating extends Canvas {
 	 * @see SelectionEvent
 	 */
 	public void addSelectionListener(final SelectionListener listener) {
-		checkWidget();
-		SelectionListenerUtil.addSelectionListener(this, listener);
+		addTypedListener(listener, SWT.Selection);
 	}
 
 	/**
@@ -323,8 +322,7 @@ public class StarRating extends Canvas {
 	 * @see #addSelectionListener
 	 */
 	public void removeSelectionListener(final SelectionListener listener) {
-		checkWidget();
-		SelectionListenerUtil.removeSelectionListener(this, listener);
+		removeTypedListener(SWT.Selection, listener);
 	}
 
 	/**

--- a/widgets/opal/switchbutton/org.eclipse.nebula.widgets.opal.switchbutton/META-INF/MANIFEST.MF
+++ b/widgets/opal/switchbutton/org.eclipse.nebula.widgets.opal.switchbutton/META-INF/MANIFEST.MF
@@ -6,6 +6,6 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.nebula.widgets.opal.commons;bundle-version="1.0.0";visibility:=reexport,
- org.eclipse.swt
+ org.eclipse.swt;bundle-version="[3.126.0,4.0.0)"
 Export-Package: org.eclipse.nebula.widgets.opal.switchbutton
 Automatic-Module-Name: org.eclipse.nebula.widgets.opal.switchbutton

--- a/widgets/opal/switchbutton/org.eclipse.nebula.widgets.opal.switchbutton/src/org/eclipse/nebula/widgets/opal/switchbutton/SwitchButton.java
+++ b/widgets/opal/switchbutton/org.eclipse.nebula.widgets.opal.switchbutton/src/org/eclipse/nebula/widgets/opal/switchbutton/SwitchButton.java
@@ -403,8 +403,7 @@ public class SwitchButton extends Canvas {
 	 * @see SelectionEvent
 	 */
 	public void addSelectionListener(final SelectionListener listener) {
-		checkWidget();
-		SelectionListenerUtil.addSelectionListener(this, listener);
+		addTypedListener(listener, SWT.Selection);
 	}
 
 	/**
@@ -429,8 +428,7 @@ public class SwitchButton extends Canvas {
 	 * @see #addSelectionListener
 	 */
 	public void removeSelectionListener(final SelectionListener listener) {
-		checkWidget();
-		SelectionListenerUtil.removeSelectionListener(this, listener);
+		removeTypedListener(SWT.Selection, listener);
 	}
 
 	/**

--- a/widgets/pgroup/org.eclipse.nebula.widgets.pgroup/META-INF/MANIFEST.MF
+++ b/widgets/pgroup/org.eclipse.nebula.widgets.pgroup/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Nebula PGroup
 Bundle-SymbolicName: org.eclipse.nebula.widgets.pgroup
 Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Eclipse Nebula
-Require-Bundle: org.eclipse.swt
+Require-Bundle: org.eclipse.swt;bundle-version="[3.126.0,4.0.0)"
 Export-Package: org.eclipse.nebula.widgets.pgroup,
  org.eclipse.nebula.widgets.pgroup.internal;x-internal:=true
 Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/widgets/pgroup/org.eclipse.nebula.widgets.pgroup/src/org/eclipse/nebula/widgets/pgroup/PGroup.java
+++ b/widgets/pgroup/org.eclipse.nebula.widgets.pgroup/src/org/eclipse/nebula/widgets/pgroup/PGroup.java
@@ -37,7 +37,6 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Listener;
-import org.eclipse.swt.widgets.TypedListener;
 import org.eclipse.swt.widgets.Widget;
 
 /**
@@ -692,13 +691,7 @@ public class PGroup extends Canvas
      */
     public void addExpandListener(ExpandListener listener)
     {
-        checkWidget();
-        if (listener == null)
-            SWT.error(SWT.ERROR_NULL_ARGUMENT);
-
-        TypedListener typedListener = new TypedListener(listener);
-        addListener(SWT.Expand, typedListener);
-        addListener(SWT.Collapse, typedListener);
+        addTypedListener(listener, SWT.Expand, SWT.Collapse);
     }
 
     /**
@@ -720,12 +713,8 @@ public class PGroup extends Canvas
      */
     public void removeExpandListener(ExpandListener listener)
     {
-        checkWidget();
-        if (listener == null)
-            SWT.error(SWT.ERROR_NULL_ARGUMENT);
-
-        removeListener(SWT.Expand, listener);
-        removeListener(SWT.Collapse, listener);
+        removeTypedListener(SWT.Expand, listener);
+        removeTypedListener(SWT.Collapse, listener);
     }
 
     /**

--- a/widgets/pgroup/org.eclipse.nebula.widgets.pgroup/src/org/eclipse/nebula/widgets/pgroup/PGroupToolItem.java
+++ b/widgets/pgroup/org.eclipse.nebula.widgets.pgroup/src/org/eclipse/nebula/widgets/pgroup/PGroupToolItem.java
@@ -18,7 +18,6 @@ import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Item;
-import org.eclipse.swt.widgets.TypedListener;
 
 /**
  * Instances of this class represent a selectable user interface object that
@@ -76,14 +75,12 @@ public class PGroupToolItem extends Item {
 	}
 
 	public void addSelectionListener(SelectionListener listener) {
-		TypedListener typedListener = new TypedListener(listener);
-		addListener(SWT.Selection, typedListener);
-		addListener(SWT.DefaultSelection, typedListener);
+		addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 	}
 
 	public void removeSelectionListener(SelectionListener listener) {
-		removeListener(SWT.Selection, listener);
-		removeListener(SWT.DefaultSelection, listener);
+		removeTypedListener(SWT.Selection, listener);
+		removeTypedListener(SWT.DefaultSelection, listener);
 	}
 
 	void setDropDownArea(Rectangle dropdownArea) {

--- a/widgets/pshelf/org.eclipse.nebula.widgets.pshelf/META-INF/MANIFEST.MF
+++ b/widgets/pshelf/org.eclipse.nebula.widgets.pshelf/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Nebula PShelf
 Bundle-SymbolicName: org.eclipse.nebula.widgets.pshelf
 Bundle-Version: 1.1.0.qualifier
 Bundle-Vendor: Eclipse Nebula
-Require-Bundle: org.eclipse.swt,
+Require-Bundle: org.eclipse.swt;bundle-version="[3.126.0,4.0.0)",
  org.eclipse.jface,
  org.eclipse.core.runtime,
  org.eclipse.nebula.widgets.opal.commons

--- a/widgets/pshelf/org.eclipse.nebula.widgets.pshelf/src/org/eclipse/nebula/widgets/pshelf/PShelf.java
+++ b/widgets/pshelf/org.eclipse.nebula.widgets.pshelf/src/org/eclipse/nebula/widgets/pshelf/PShelf.java
@@ -25,7 +25,6 @@ import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Canvas;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Event;
-import org.eclipse.swt.widgets.TypedListener;
 
 /**
  * <p>
@@ -594,11 +593,7 @@ public class PShelf extends Canvas {
      * @see SelectionEvent
      */
     public void addSelectionListener(SelectionListener listener) {
-        checkWidget ();
-        if (listener == null) SWT.error (SWT.ERROR_NULL_ARGUMENT);
-        TypedListener typedListener = new TypedListener(listener);
-        addListener(SWT.Selection,typedListener);
-        addListener(SWT.DefaultSelection,typedListener);
+    	addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
     }
 
     /**
@@ -619,11 +614,8 @@ public class PShelf extends Canvas {
      * @see #addSelectionListener
      */
     public void removeSelectionListener (SelectionListener listener) {
-        checkWidget ();
-        if (listener == null) SWT.error (SWT.ERROR_NULL_ARGUMENT);
-
-        removeListener(SWT.Selection, listener);
-        removeListener(SWT.DefaultSelection,listener);
+    	removeTypedListener(SWT.Selection, listener);
+    	removeTypedListener(SWT.DefaultSelection,listener);
     }
 
 	/**

--- a/widgets/radiogroup/org.eclipse.nebula.widgets.radiogroup/META-INF/MANIFEST.MF
+++ b/widgets/radiogroup/org.eclipse.nebula.widgets.radiogroup/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 0.1.0.qualifier
 Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.equinox.common,
- org.eclipse.swt,
+ org.eclipse.swt;bundle-version="[3.126.0,4.0.0)",
  org.eclipse.jface,
  org.eclipse.core.databinding;bundle-version="1.2.0",
  org.eclipse.core.databinding.property;bundle-version="1.2.0",

--- a/widgets/radiogroup/org.eclipse.nebula.widgets.radiogroup/src/org/eclipse/nebula/widgets/radiogroup/RadioGroup.java
+++ b/widgets/radiogroup/org.eclipse.nebula.widgets.radiogroup/src/org/eclipse/nebula/widgets/radiogroup/RadioGroup.java
@@ -26,7 +26,6 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Item;
 import org.eclipse.swt.widgets.Layout;
-import org.eclipse.swt.widgets.TypedListener;
 import org.eclipse.swt.widgets.Widget;
 
 /**
@@ -199,13 +198,7 @@ public class RadioGroup extends Composite {
 	 * @see SelectionEvent
 	 */
 	public void addSelectionListener(SelectionListener listener) {
-		checkWidget();
-		if (listener == null) {
-			SWT.error(SWT.ERROR_NULL_ARGUMENT);
-		}
-		final TypedListener typedListener = new TypedListener(listener);
-		addListener(SWT.Selection, typedListener);
-		addListener(SWT.DefaultSelection, typedListener);
+		addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 	}
 
 	private int checkAddPosition(int position) {
@@ -573,9 +566,8 @@ public class RadioGroup extends Composite {
 	 * @see #addSelectionListener
 	 */
 	public void removeSelectionListener(SelectionListener listener) {
-		checkWidget();
-		removeListener(SWT.Selection, listener);
-		removeListener(SWT.DefaultSelection, listener);
+		removeTypedListener(SWT.Selection, listener);
+		removeTypedListener(SWT.DefaultSelection, listener);
 	}
 
 	/**

--- a/widgets/roundedcheckbox/org.eclipse.nebula.widgets.roundedcheckbox/META-INF/MANIFEST.MF
+++ b/widgets/roundedcheckbox/org.eclipse.nebula.widgets.roundedcheckbox/META-INF/MANIFEST.MF
@@ -6,6 +6,6 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.nebula.widgets.opal.commons;bundle-version="1.0.0";visibility:=reexport,
- org.eclipse.swt
+ org.eclipse.swt;bundle-version="[3.126.0,4.0.0)"
 Export-Package: org.eclipse.nebula.widgets.roundedcheckbox
 Automatic-Module-Name: org.eclipse.nebula.widgets.roundedcheckbox

--- a/widgets/roundedcheckbox/org.eclipse.nebula.widgets.roundedcheckbox/src/org/eclipse/nebula/widgets/roundedcheckbox/RoundedCheckbox.java
+++ b/widgets/roundedcheckbox/org.eclipse.nebula.widgets.roundedcheckbox/src/org/eclipse/nebula/widgets/roundedcheckbox/RoundedCheckbox.java
@@ -240,8 +240,7 @@ public class RoundedCheckbox extends Canvas {
 	 * @see SelectionEvent
 	 */
 	public void addSelectionListener(final SelectionListener listener) {
-		checkWidget();
-		SelectionListenerUtil.addSelectionListener(this, listener);
+		addTypedListener(listener, SWT.Selection);
 	}
 
 	/**
@@ -391,8 +390,7 @@ public class RoundedCheckbox extends Canvas {
 	 * @see #addSelectionListener
 	 */
 	public void removeSelectionListener(final SelectionListener listener) {
-		checkWidget();
-		SelectionListenerUtil.removeSelectionListener(this, listener);
+		removeTypedListener(SWT.Selection, listener);
 	}
 
 	/**

--- a/widgets/roundedswitch/org.eclipse.nebula.widgets.roundedswitch/META-INF/MANIFEST.MF
+++ b/widgets/roundedswitch/org.eclipse.nebula.widgets.roundedswitch/META-INF/MANIFEST.MF
@@ -7,5 +7,5 @@ Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.eclipse.nebula.widgets.roundedswitch
 Require-Bundle: org.eclipse.nebula.widgets.opal.commons;visibility:=reexport,
- org.eclipse.swt
+ org.eclipse.swt;bundle-version="[3.126.0,4.0.0)"
 Automatic-Module-Name: org.eclipse.nebula.widgets.roundedswitch

--- a/widgets/roundedswitch/org.eclipse.nebula.widgets.roundedswitch/src/org/eclipse/nebula/widgets/roundedswitch/RoundedSwitch.java
+++ b/widgets/roundedswitch/org.eclipse.nebula.widgets.roundedswitch/src/org/eclipse/nebula/widgets/roundedswitch/RoundedSwitch.java
@@ -253,8 +253,7 @@ public class RoundedSwitch extends Canvas {
 	 * @see SelectionEvent
 	 */
 	public void addSelectionListener(final SelectionListener listener) {
-		checkWidget();
-		SelectionListenerUtil.addSelectionListener(this, listener);
+		addTypedListener(listener, SWT.Selection);
 	}
 
 	/**
@@ -321,8 +320,7 @@ public class RoundedSwitch extends Canvas {
 	 * @see #addSelectionListener
 	 */
 	public void removeSelectionListener(final SelectionListener listener) {
-		checkWidget();
-		SelectionListenerUtil.removeSelectionListener(this, listener);
+		removeTypedListener(SWT.Selection, listener);
 	}
 
 	/**

--- a/widgets/tablecombo/org.eclipse.nebula.widgets.tablecombo/META-INF/MANIFEST.MF
+++ b/widgets/tablecombo/org.eclipse.nebula.widgets.tablecombo/META-INF/MANIFEST.MF
@@ -9,6 +9,6 @@ Export-Package: org.eclipse.nebula.jface.checktablecomboviewer,
  org.eclipse.nebula.widgets.tablecombo
 Automatic-Module-Name: org.eclipse.nebula.widgets.tablecombo
 Bundle-RequiredExecutionEnvironment: JavaSE-11
-Require-Bundle: org.eclipse.swt,
+Require-Bundle: org.eclipse.swt;bundle-version="[3.126.0,4.0.0)",
  org.eclipse.jface;resolution:=optional
 Bundle-Vendor: Eclipse Nebula

--- a/widgets/tablecombo/org.eclipse.nebula.widgets.tablecombo/src/org/eclipse/nebula/widgets/tablecombo/TableCombo.java
+++ b/widgets/tablecombo/org.eclipse.nebula.widgets.tablecombo/src/org/eclipse/nebula/widgets/tablecombo/TableCombo.java
@@ -57,7 +57,6 @@ import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.swt.widgets.TableItem;
 import org.eclipse.swt.widgets.Text;
-import org.eclipse.swt.widgets.TypedListener;
 import org.eclipse.swt.widgets.Widget;
 
 /**
@@ -342,12 +341,7 @@ public class TableCombo extends Composite {
 	 * @see #removeModifyListener
 	 */
 	public void addModifyListener(final ModifyListener listener) {
-		checkWidget();
-		if (listener == null) {
-			SWT.error(SWT.ERROR_NULL_ARGUMENT);
-		}
-		final TypedListener typedListener = new TypedListener(listener);
-		addListener(SWT.Modify, typedListener);
+		addTypedListener(listener, SWT.Modify);
 	}
 
 	/**
@@ -381,14 +375,7 @@ public class TableCombo extends Composite {
 	 * @see SelectionEvent
 	 */
 	public void addSelectionListener(final SelectionListener listener) {
-		checkWidget();
-		if (listener == null) {
-			SWT.error(SWT.ERROR_NULL_ARGUMENT);
-		}
-
-		final TypedListener typedListener = new TypedListener(listener);
-		addListener(SWT.Selection, typedListener);
-		addListener(SWT.DefaultSelection, typedListener);
+		addTypedListener(listener, SWT.Selection, SWT.DefaultSelection);
 	}
 
 	/**
@@ -473,12 +460,7 @@ public class TableCombo extends Composite {
 	 * @since 3.3
 	 */
 	public void addVerifyListener(final VerifyListener listener) {
-		checkWidget();
-		if (listener == null) {
-			SWT.error(SWT.ERROR_NULL_ARGUMENT);
-		}
-		final TypedListener typedListener = new TypedListener(listener);
-		addListener(SWT.Verify, typedListener);
+		addTypedListener(listener, SWT.Verify);
 	}
 
 	/**
@@ -1818,11 +1800,7 @@ public class TableCombo extends Composite {
 	 * @see #addModifyListener
 	 */
 	public void removeModifyListener(final ModifyListener listener) {
-		checkWidget();
-		if (listener == null) {
-			SWT.error(SWT.ERROR_NULL_ARGUMENT);
-		}
-		removeListener(SWT.Modify, listener);
+		removeTypedListener(SWT.Modify, listener);
 	}
 
 	/**
@@ -1848,12 +1826,8 @@ public class TableCombo extends Composite {
 	 * @see #addSelectionListener
 	 */
 	public void removeSelectionListener(final SelectionListener listener) {
-		checkWidget();
-		if (listener == null) {
-			SWT.error(SWT.ERROR_NULL_ARGUMENT);
-		}
-		removeListener(SWT.Selection, listener);
-		removeListener(SWT.DefaultSelection, listener);
+		removeTypedListener(SWT.Selection, listener);
+		removeTypedListener(SWT.DefaultSelection, listener);
 	}
 
 	/**
@@ -1881,11 +1855,7 @@ public class TableCombo extends Composite {
 	 * @since 3.3
 	 */
 	public void removeVerifyListener(final VerifyListener listener) {
-		checkWidget();
-		if (listener == null) {
-			SWT.error(SWT.ERROR_NULL_ARGUMENT);
-		}
-		removeListener(SWT.Verify, listener);
+		removeTypedListener(SWT.Verify, listener);
 	}
 
 	/**

--- a/widgets/tiles/org.eclipse.nebula.widgets.tiles/META-INF/MANIFEST.MF
+++ b/widgets/tiles/org.eclipse.nebula.widgets.tiles/META-INF/MANIFEST.MF
@@ -6,5 +6,5 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.eclipse.nebula.widgets.tiles
-Require-Bundle: org.eclipse.swt
+Require-Bundle: org.eclipse.swt;bundle-version="[3.126.0,4.0.0)"
 Automatic-Module-Name: org.eclipse.nebula.widgets.tiles

--- a/widgets/tiles/org.eclipse.nebula.widgets.tiles/src/org/eclipse/nebula/widgets/tiles/Tiles.java
+++ b/widgets/tiles/org.eclipse.nebula.widgets.tiles/src/org/eclipse/nebula/widgets/tiles/Tiles.java
@@ -35,7 +35,6 @@ import org.eclipse.swt.graphics.Transform;
 import org.eclipse.swt.widgets.Canvas;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Event;
-import org.eclipse.swt.widgets.TypedListener;
 
 /**
  *
@@ -109,8 +108,7 @@ public class Tiles<T> extends Canvas {
 	 * @param listener
 	 */
 	public void addSelectionListener(final SelectionListener listener) {
-		super.checkWidget();
-		addListener(SWT.Selection, new TypedListener(listener));
+		addTypedListener(listener, SWT.Selection);
 	}
 
 	/**
@@ -253,8 +251,7 @@ public class Tiles<T> extends Canvas {
 	 * @param listener
 	 */
 	public void removeSelectionListener(final SelectionListener listener) {
-		super.checkWidget();
-		removeListener(SWT.Selection, listener);
+		removeTypedListener(SWT.Selection, listener);
 	}
 
 	/**


### PR DESCRIPTION
The `org.eclipse.swt.widgets.TypedListener` should be considered an internal class (as the doc states) and leaks the class `SWTEventListener` which also resides in an internal package.

Leverage new methods introduced in https://github.com/eclipse-platform/eclipse.platform.swt/pull/1112 in order to avoid the usage of that two classes. I don't know if there is a specific backwards compatibility policy in Nebula regarding SWT, but at the moment the new methods are only available in Eclipse I-builds. I guess therefore this change cannot be applied immediately.
In order to demonstrate it works I changed temporarily changed the target-platform of the build.

@lcaron could you please have a look at this one?

@Phillipus for your information (if you want to review this too, please do so).