### PR TITLE
Simplify maven build workflow and update actions

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -12,27 +12,21 @@ jobs:
         java: [ '17' ]
     name: Java ${{ matrix.java }} compile
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         distribution: 'temurin' # See 'Supported distributions' for available options
         java-version: ${{ matrix.java }}
-    - name: Install xvfb
-      run: sudo apt-get install xvfb
-    - name: Cache local Maven repository
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          ${{ runner.os }}-maven-   
+        cache: 'maven'
     - name: Set up Maven
       uses: stCarolas/setup-maven@07fbbe97d97ef44336b7382563d66743297e442f # v4.5
       with:
         maven-version: 3.9.6
     - name: Build All Widgets
-      run: xvfb-run mvn -V clean verify  -Dtycho.localArtifacts=ignore
+      uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3 # v1.0.1
+      with:
+       run: mvn -V -B clean verify -Dtycho.localArtifacts=ignore
 #    - name: Build Incubation Widgets
 #      run: xvfb-run mvn -V clean verify -Pincubation  -Dtycho.localArtifacts=ignore
 #    - name: Publish Unit Test Results


### PR DESCRIPTION
Use the maven-caching integrated into the setup-java action to replace the explicit usage of actions/cache:
https://github.com/actions/setup-java/?tab=readme-ov-file#caching-maven-dependencies

Use the https://github.com/coactions/setup-xvfb instead of installing xvfb manually.

Run Maven in --batch-mode to suppress transfer print-out.