### PR TITLE
Disable move on double-click

### DIFF
--- a/widgets/nebulaslider/org.eclipse.nebula.widgets.nebulaslider/src/org/eclipse/nebula/widgets/opal/nebulaslider/NebulaSlider.java
+++ b/widgets/nebulaslider/org.eclipse.nebula.widgets.nebulaslider/src/org/eclipse/nebula/widgets/opal/nebulaslider/NebulaSlider.java
@@ -266,8 +266,15 @@ public class NebulaSlider extends Canvas {
 				mouseDeltaX = xPosition - e.x;
 			}
 		});
+		addListener(SWT.MouseDoubleClick, e -> {
+			moving = false;
+			mouseDeltaX = 0;
+		});
 
 		addListener(SWT.MouseUp, e -> {
+			if(!moving) {
+				return;
+			}
 			moving = false;
 			mouseDeltaX = 0;
 			if(movingValue != value) {


### PR DESCRIPTION
Sometimes it could happen that if one double click on a control the slider "hangs" from then on as the control does not receive a "MousUp" event and then the follow the mouse without actually holding it down.

This now additionally registers a MouseDoubleClick handler that disable the move operation.