### PR TITLE
Move RadioGroup from incubation to release

### DIFF
--- a/releng/org.eclipse.nebula.examples.incubation.feature/feature.xml
+++ b/releng/org.eclipse.nebula.examples.incubation.feature/feature.xml
@@ -36,14 +36,6 @@
          version="0.0.0"/>
 
    <plugin
-         id="org.eclipse.nebula.widgets.radiogroup.example"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.nebula.widgets.radiogroup.example.source"
-         version="0.0.0"/>
-
-   <plugin
          id="org.eclipse.nebula.widgets.pagination.example"
          version="0.0.0"/>
 

--- a/releng/org.eclipse.nebula.examples.release.feature/feature.xml
+++ b/releng/org.eclipse.nebula.examples.release.feature/feature.xml
@@ -492,5 +492,13 @@
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+           id="org.eclipse.nebula.widgets.radiogroup.example"
+           version="0.0.0"/>
+
+   <plugin
+           id="org.eclipse.nebula.widgets.radiogroup.example.source"
+           version="0.0.0"/>
+
 
 </feature>

--- a/releng/org.eclipse.nebula.feature/feature.xml
+++ b/releng/org.eclipse.nebula.feature/feature.xml
@@ -261,4 +261,8 @@
          id="org.eclipse.nebula.widgets.treemapper.feature"
          version="0.0.0"/>
 
+   <includes
+         id="org.eclipse.nebula.widgets.radiogroup.feature"
+         version="0.0.0"/>
+
 </feature>

--- a/releng/org.eclipse.nebula.incubation.feature/feature.xml
+++ b/releng/org.eclipse.nebula.incubation.feature/feature.xml
@@ -30,10 +30,6 @@
          version="0.0.0"/>
 
    <includes
-         id="org.eclipse.nebula.widgets.radiogroup.feature"
-         version="0.0.0"/>
-
-   <includes
          id="org.eclipse.nebula.widgets.pagination.feature"
          version="0.0.0"/>
 

--- a/releng/org.eclipse.nebula.nebula-parent/pom.xml
+++ b/releng/org.eclipse.nebula.nebula-parent/pom.xml
@@ -364,6 +364,7 @@ Contributors:
 		<module>../../widgets/pgroup</module>
 		<module>../../widgets/progresscircle</module>
 		<module>../../widgets/pshelf</module>
+		<module>../../widgets/radiogroup</module>
 		<module>../../widgets/richtext</module>
 		<module>../../widgets/roundedcheckbox</module>
 		<module>../../widgets/roundedswitch</module>
@@ -383,7 +384,6 @@ Contributors:
 		<module>../../widgets/datechooser</module>
 		<module>../../widgets/pagination</module>
 		<module>../../widgets/picture</module>
-		<module>../../widgets/radiogroup</module>
 		<module>../../widgets/timeline</module>
 
 		<module>../../examples/org.eclipse.nebula.examples</module>

--- a/widgets/radiogroup/org.eclipse.nebula.widgets.radiogroup.example/META-INF/MANIFEST.MF
+++ b/widgets/radiogroup/org.eclipse.nebula.widgets.radiogroup.example/META-INF/MANIFEST.MF
@@ -1,12 +1,12 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Nebula Radio Group Example - Incubating
+Bundle-Name: Nebula Radio Group Example
 Bundle-SymbolicName: org.eclipse.nebula.widgets.radiogroup.example;singleton:=true
 Bundle-Vendor: Eclipse Nebula
 Bundle-Version: 1.0.0.qualifier
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
- org.eclipse.nebula.widgets.radiogroup;bundle-version="0.1.0",
+ org.eclipse.nebula.widgets.radiogroup;bundle-version="1.0.0",
  org.eclipse.nebula.examples;bundle-version="1.0.4"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/widgets/radiogroup/org.eclipse.nebula.widgets.radiogroup.example/pom.xml
+++ b/widgets/radiogroup/org.eclipse.nebula.widgets.radiogroup.example/pom.xml
@@ -19,7 +19,7 @@ Contributors:
 	<parent>
 		<groupId>org.eclipse.nebula</groupId>
 		<artifactId>radiogroup</artifactId>
-		<version>0.1.0-SNAPSHOT</version>
+		<version>1.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.radiogroup.example</artifactId>

--- a/widgets/radiogroup/org.eclipse.nebula.widgets.radiogroup.feature/feature.xml
+++ b/widgets/radiogroup/org.eclipse.nebula.widgets.radiogroup.feature/feature.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <feature
       id="org.eclipse.nebula.widgets.radiogroup.feature"
-      label="Nebula Radio Group Widget - Incubating"
-      version="0.1.0.qualifier"
+      label="Nebula Radio Group Widget"
+      version="1.0.0.qualifier"
       provider-name="Eclipse Nebula">
 
    <description url="http://www.eclipse.org/nebula/widgets/radiogroup/radiogroup.php">

--- a/widgets/radiogroup/org.eclipse.nebula.widgets.radiogroup.feature/pom.xml
+++ b/widgets/radiogroup/org.eclipse.nebula.widgets.radiogroup.feature/pom.xml
@@ -19,11 +19,11 @@ Contributors:
 	<parent>
 		<groupId>org.eclipse.nebula</groupId>
 		<artifactId>radiogroup</artifactId>
-		<version>0.1.0-SNAPSHOT</version>
+		<version>1.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.radiogroup.feature</artifactId>
-	<version>0.1.0-SNAPSHOT</version>
+	<version>1.0.0-SNAPSHOT</version>
 	<packaging>eclipse-feature</packaging>
 
 </project>

--- a/widgets/radiogroup/org.eclipse.nebula.widgets.radiogroup.tests/META-INF/MANIFEST.MF
+++ b/widgets/radiogroup/org.eclipse.nebula.widgets.radiogroup.tests/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Nebula Radio Group Tests - Incubating
+Bundle-Name: Nebula Radio Group Tests
 Bundle-SymbolicName: org.eclipse.nebula.widgets.radiogroup.tests
 Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Eclipse Nebula

--- a/widgets/radiogroup/org.eclipse.nebula.widgets.radiogroup.tests/pom.xml
+++ b/widgets/radiogroup/org.eclipse.nebula.widgets.radiogroup.tests/pom.xml
@@ -21,7 +21,7 @@ Contributors:
 	<parent>
 		<groupId>org.eclipse.nebula</groupId>
 		<artifactId>radiogroup</artifactId>
-		<version>0.1.0-SNAPSHOT</version>
+		<version>1.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.radiogroup.tests</artifactId>

--- a/widgets/radiogroup/org.eclipse.nebula.widgets.radiogroup/META-INF/MANIFEST.MF
+++ b/widgets/radiogroup/org.eclipse.nebula.widgets.radiogroup/META-INF/MANIFEST.MF
@@ -1,8 +1,8 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Nebula Radio Group - Incubating
+Bundle-Name: Nebula Radio Group
 Bundle-SymbolicName: org.eclipse.nebula.widgets.radiogroup
-Bundle-Version: 0.1.0.qualifier
+Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.equinox.common,

--- a/widgets/radiogroup/org.eclipse.nebula.widgets.radiogroup/pom.xml
+++ b/widgets/radiogroup/org.eclipse.nebula.widgets.radiogroup/pom.xml
@@ -19,7 +19,7 @@ Contributors:
 	<parent>
 		<groupId>org.eclipse.nebula</groupId>
 		<artifactId>radiogroup</artifactId>
-		<version>0.1.0-SNAPSHOT</version>
+		<version>1.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.radiogroup</artifactId>

--- a/widgets/radiogroup/pom.xml
+++ b/widgets/radiogroup/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 
 	<artifactId>radiogroup</artifactId>
-	<version>0.1.0-SNAPSHOT</version>
+	<version>1.0.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<modules>


### PR DESCRIPTION
Hello and thank you for maintaining Nebula!

Would it be possible to add **RadioGroup** to *release*? A project I am maintaining is using it since ~2012.

Please let me know here in case there are any additional requirement regarding the transition.

linked issue: https://github.com/eclipse/nebula/issues/515 (FormattedText to release)