### PR TITLE
If WordWrap is enabled the alignment is ignored

### DIFF
--- a/widgets/grid/org.eclipse.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/internal/DefaultColumnHeaderRenderer.java
+++ b/widgets/grid/org.eclipse.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/internal/DefaultColumnHeaderRenderer.java
@@ -86,6 +86,7 @@ public class DefaultColumnHeaderRenderer extends GridHeaderRenderer
           getTextLayout(gc, column);
             textLayout.setText(column.getText());
             textLayout.setWidth(plainTextWidth < 1 ? 1 : plainTextWidth);
+			textLayout.setAlignment(getHorizontalAlignment());
 
             x += plainTextWidth + rightMargin;
 
@@ -202,6 +203,7 @@ public class DefaultColumnHeaderRenderer extends GridHeaderRenderer
         	getTextLayout(gc, column);
         	textLayout.setWidth(width < 1 ? 1 : width);
         	textLayout.setText(text);
+        	textLayout.setAlignment(getHorizontalAlignment());
         	y -= textLayout.getBounds().height;
 
         	// remove the first line shift


### PR DESCRIPTION
Currently if one set wordwrap to true a textlayout is used to render the text, but if one combines this with for example a center align the text still is left aligned.

This now sets the alignment into the textlayout to perform desired rendering.