### PR TITLE
Preparations for a 3.2.0 release

### DIFF
--- a/oomph.setup
+++ b/oomph.setup
@@ -120,9 +120,7 @@
   <setupTask
       xsi:type="setup.p2:P2Task">
     <repository
-        url="http://download.eclipse.org/nebula/snapshot"/>
-    <repository
-        url="http://download.eclipse.org/nebula/incubation/snapshot"/>
+        url="http://download.eclipse.org/nebula/updates/nightly/latest"/>
     <description>Install the tools needed in the IDE to work with the source code for ${scope.project.label}</description>
   </setupTask>
   <setupTask

--- a/releng/org.eclipse.nebula.nebula-parent/Build Nebula.launch
+++ b/releng/org.eclipse.nebula.nebula-parent/Build Nebula.launch
@@ -11,7 +11,7 @@
         <listEntry value="org.eclipse.justj.p2.manager.args=-remote localhost:${nebula.git.clone.location}/releng/org.eclipse.nebula.site"/>
         <listEntry value="build.type=nightly"/>
         <listEntry value="git.commit=4140e9828cc4a0be360b761c54413efd5dcd0ded"/>
-        <listEntry value="target-platform=https://download.eclipse.org/releases/2024-03"/>
+        <listEntry value="target-platform=https://download.eclipse.org/releases/milestone"/>
     </listAttribute>
     <stringAttribute key="M2_RUNTIME" value="EMBEDDED"/>
     <booleanAttribute key="M2_SKIP_TESTS" value="false"/>

--- a/releng/org.eclipse.nebula.nebula-parent/pom.xml
+++ b/releng/org.eclipse.nebula.nebula-parent/pom.xml
@@ -33,7 +33,7 @@ Contributors:
 		<jacoco-version>0.8.9</jacoco-version>
 		<easymock-version>5.2.0</easymock-version>
 
-		<target-platform>https://download.eclipse.org/releases/latest</target-platform>
+		<target-platform>https://download.eclipse.org/releases/milestone</target-platform>
 
 		<maven.compiler.source>17</maven.compiler.source>
 		<maven.compiler.target>17</maven.compiler.target>

--- a/widgets/grid/org.eclipse.nebula.widgets.grid.test/META-INF/MANIFEST.MF
+++ b/widgets/grid/org.eclipse.nebula.widgets.grid.test/META-INF/MANIFEST.MF
@@ -4,13 +4,10 @@ Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-SymbolicName: org.eclipse.nebula.widgets.grid.test
 Bundle-Version: 0.3.0.qualifier
-Require-Bundle: org.junit;bundle-version="4.8.2"
+Require-Bundle: org.junit;bundle-version="4.8.2",
+ org.eclipse.rap.rwt.testfixture;resolution:=optional
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11
-Import-Package:  org.eclipse.rap.rwt.testfixture;version="[3.0.0,5.0.0)",
- org.eclipse.rap.rwt.testfixture.internal;version="[3.0.0,5.0.0)",
- org.eclipse.rap.rwt.testfixture.internal.engine;version="[3.0.0,5.0.0)",
- org.eclipse.rap.rwt.testfixture.internal.service;version="[3.0.0,5.0.0)"
 Export-Package: org.eclipse.nebula.widgets.grid
 Fragment-Host: org.eclipse.nebula.widgets.grid;bundle-version="1.0.0.qualifier"
 Bundle-ClassPath: mockito-core-1.8.4.jar,


### PR DESCRIPTION
- Update the p2 task to use http://download.eclipse.org/nebula/updates/nightly/latest
- Update the build to use https://download.eclipse.org/releases/milestone to build always by default against the most recent SimRel content.
- Update org.eclipse.nebula.widgets.grid.test to use bundle org.eclipse.rap.rwt.testfixture optional to avoid forcing RAP into the target platform.
  - I don't believe support for RAP/rwt actually works.
  - Also, this fragment isn't actually used as part of the build.

https://github.com/eclipse/nebula/issues/616