### PR TITLE
TableCombo dropdown doesn't scale the drop down after the dpi change

### DIFF
--- a/widgets/tablecombo/org.eclipse.nebula.widgets.tablecombo/src/org/eclipse/nebula/widgets/tablecombo/TableCombo.java
+++ b/widgets/tablecombo/org.eclipse.nebula.widgets.tablecombo/src/org/eclipse/nebula/widgets/tablecombo/TableCombo.java
@@ -1500,6 +1500,7 @@ public class TableCombo extends Composite {
 		if (closeDropDown && isDropped()) {
 			dropDown(false);
 		}
+		recreatePopup();
 		final Rectangle rect = getClientArea();
 		final int width = rect.width;
 		final int height = rect.height;


### PR DESCRIPTION
During the dpi change, when you try to open the combo drop down for the first time, the size of the drop down is smaller and looks weird. Recreating popup when resize event occurs solves the issue. 

## Before Fix
![image](https://github.com/user-attachments/assets/759908d7-7362-4f6c-a216-fadfd7cc08b4)

## After Fix
![image](https://github.com/user-attachments/assets/49d6ab28-ec47-4964-8ae1-265c2e451cb6)


## HOW TO TEST
- Run the `TableComboSnippet1` with the following **VM Arguments**
```
-Dswt.autoScale=quarter
-Dswt.autoScale.updateOnRuntime=true
```
- Click on drop down arrow
- Move the window to other screen
- Try opening the drop down again
- See if the drop down menu is same width as the combo box.