### PR TITLE
Correctly report the required size to paint the PGroup control

### DIFF
--- a/widgets/pgroup/org.eclipse.nebula.widgets.pgroup/src/org/eclipse/nebula/widgets/pgroup/FormGroupStrategy.java
+++ b/widgets/pgroup/org.eclipse.nebula.widgets.pgroup/src/org/eclipse/nebula/widgets/pgroup/FormGroupStrategy.java
@@ -360,7 +360,7 @@ public class FormGroupStrategy extends AbstractGroupStrategy
      */
     public Rectangle computeTrim(int x, int y, int width, int height)
     {
-        Rectangle area = new Rectangle(x, y, width, height);
+        Rectangle area = new Rectangle(x, y, Math.max(0, width), Math.max(0, height));
         area.x -= margin;
         area.y -= titleHeight;
         area.width += (2 * margin);

--- a/widgets/pgroup/org.eclipse.nebula.widgets.pgroup/src/org/eclipse/nebula/widgets/pgroup/PGroup.java
+++ b/widgets/pgroup/org.eclipse.nebula.widgets.pgroup/src/org/eclipse/nebula/widgets/pgroup/PGroup.java
@@ -612,16 +612,20 @@ public class PGroup extends Canvas
     /** 
      * @see org.eclipse.swt.widgets.Control#computeSize(int, int, boolean)
      */
-    public Point computeSize(int arg0, int arg1, boolean arg2)
-    {
-        checkWidget();
-        if (getExpanded())
-            return super.computeSize(arg0, arg1, arg2);
-
-        Rectangle trim = strategy.computeTrim(0, 0, 0, 0);
-        trim.width = super.computeSize(arg0, arg1, arg2).x;
-        return new Point(trim.width, Math.max(trim.height, arg1));
-    }
+    @Override
+	public Point computeSize(int wHint, int hHint, boolean changed) {
+		checkWidget();
+		if(changed) {
+			strategy.update();
+		}
+		Rectangle trim = strategy.computeTrim(0, 0, wHint, 0);
+		Point controlSize = super.computeSize(wHint, hHint, changed);
+		if(!getExpanded()) {
+			controlSize.y = Math.max(trim.height, hHint);
+		}
+		controlSize.x = Math.max(Math.max(controlSize.x, trim.width), wHint);
+		return controlSize;
+	}
 
     /**
      * Returns the expanded/collapsed state.

--- a/widgets/pgroup/org.eclipse.nebula.widgets.pgroup/src/org/eclipse/nebula/widgets/pgroup/SimpleGroupStrategy.java
+++ b/widgets/pgroup/org.eclipse.nebula.widgets.pgroup/src/org/eclipse/nebula/widgets/pgroup/SimpleGroupStrategy.java
@@ -265,7 +265,7 @@ public class SimpleGroupStrategy extends AbstractGroupStrategy
      */
     public Rectangle computeTrim(int x, int y, int width, int height)
     {
-        Rectangle area = new Rectangle(x, y, width, height);
+        Rectangle area = new Rectangle(x, y, Math.max(0, width), Math.max(0, height));
         area.y -= titleHeight;
         area.height += titleHeight;
         return area;


### PR DESCRIPTION
Currently if the the content of the PGroup is smaller than the title area width the text is cropped and possibly not readable because the PGroup does not report the title area with as it preferred width.

This now changes the computation so that the hints are passed to the render and then it could report the desired size.

The problem can be seen with the [PGroupSnippet1.java](https://github.com/EclipseNebula/nebula/blob/master/examples/org.eclipse.nebula.snippets/src/org/eclipse/nebula/snippets/pgroup/PGroupSnippet1.java) already here it is how it is shown before (under Linux):

![pgroup_before](https://github.com/user-attachments/assets/72ac5e32-eee5-490e-a553-8b17d068249a)

As one can see, even though there is enough space left, the title is abbreviated and hardly readable.

After this change it looks like this:

![pgroup_after](https://github.com/user-attachments/assets/03a0ca63-8e23-4b2f-a143-7ba1f6085902)
