### PR TITLE
Alignment for second PShelf item is broken

### DIFF
--- a/widgets/pshelf/org.eclipse.nebula.widgets.pshelf/src/org/eclipse/nebula/widgets/pshelf/PaletteShelfRenderer.java
+++ b/widgets/pshelf/org.eclipse.nebula.widgets.pshelf/src/org/eclipse/nebula/widgets/pshelf/PaletteShelfRenderer.java
@@ -55,7 +55,6 @@ public class PaletteShelfRenderer extends AbstractRenderer {
 		return new Point(wHint,h);
 	}
 
-
 	/**
      * {@inheritDoc}
      */
@@ -63,6 +62,7 @@ public class PaletteShelfRenderer extends AbstractRenderer {
 	public void paint(GC gc, Object value)
     {
         PShelfItem item = (PShelfItem)value;
+		int fontHeight = gc.getFontMetrics().getHeight();
 
 		Color fore = parent.getForeground();
 
@@ -92,8 +92,8 @@ public class PaletteShelfRenderer extends AbstractRenderer {
 		}
 		gc.setForeground(fore);
 
-		int y2 = (getBounds().height - gc.getFontMetrics().getHeight())/2;
-		if ((getBounds().height - gc.getFontMetrics().getHeight()) % 2 != 0)
+		int y2 = (getBounds().height - fontHeight)/2;
+		if ((getBounds().height - fontHeight) % 2 != 0)
 			y2 ++;
 
         if (isHover() && !isSelected())


### PR DESCRIPTION
Alignment is broken for all n+1 items is broken because GC returns wrong height from the font metrics.

### How to Test

> Run the PShelfSnippet1 with the following VM Arguments on 200% monitor (Also happens for 100% but difference is not that much visible)

```
-Dswt.autoScale=quarter
-Dswt.autoScale.updateOnRuntime=true
```
> See if the second item is properly aligned vertically.

### Before Fix
![image](https://github.com/user-attachments/assets/ec2eb834-b50a-409c-9158-f9404b03999e)

### After Fix
![image](https://github.com/user-attachments/assets/6249e6c1-a00c-419c-a59a-3666798e4f84)


