### PR TITLE
Implement drop down in RoundedToolbar

### DIFF
--- a/widgets/opal/roundedtoolbar/org.eclipse.nebula.widgets.opal.roundedtoolbar.snippets/.classpath
+++ b/widgets/opal/roundedtoolbar/org.eclipse.nebula.widgets.opal.roundedtoolbar.snippets/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/widgets/opal/roundedtoolbar/org.eclipse.nebula.widgets.opal.roundedtoolbar.snippets/.settings/org.eclipse.jdt.core.prefs
+++ b/widgets/opal/roundedtoolbar/org.eclipse.nebula.widgets.opal.roundedtoolbar.snippets/.settings/org.eclipse.jdt.core.prefs
@@ -1,10 +1,10 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
-org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
+org.eclipse.jdt.core.compiler.compliance=17
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
-org.eclipse.jdt.core.compiler.source=11
+org.eclipse.jdt.core.compiler.source=17

--- a/widgets/opal/roundedtoolbar/org.eclipse.nebula.widgets.opal.roundedtoolbar.snippets/META-INF/MANIFEST.MF
+++ b/widgets/opal/roundedtoolbar/org.eclipse.nebula.widgets.opal.roundedtoolbar.snippets/META-INF/MANIFEST.MF
@@ -4,7 +4,8 @@ Bundle-Name: Nebula Opal Rounded Toolbar Snippets
 Bundle-SymbolicName: org.eclipse.nebula.widgets.opal.roundedtoolbar.snippets
 Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Eclipse Nebula
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.nebula.widgets.opal.roundedtoolbar;bundle-version="1.0.0",
- org.eclipse.swt
+ org.eclipse.swt,
+ org.eclipse.jface
 Automatic-Module-Name: org.eclipse.nebula.widgets.opal.roundedtoolbar.snippets

--- a/widgets/opal/roundedtoolbar/org.eclipse.nebula.widgets.opal.roundedtoolbar.snippets/src/org/eclipse/nebula/widgets/opal/roundedtoolbar/snippets/RoundedToolbarSnippet.java
+++ b/widgets/opal/roundedtoolbar/org.eclipse.nebula.widgets.opal.roundedtoolbar.snippets/src/org/eclipse/nebula/widgets/opal/roundedtoolbar/snippets/RoundedToolbarSnippet.java
@@ -13,15 +13,21 @@
  *******************************************************************************/
 package org.eclipse.nebula.widgets.opal.roundedtoolbar.snippets;
 
+import org.eclipse.jface.action.IMenuCreator;
 import org.eclipse.nebula.widgets.opal.roundedtoolbar.RoundedToolItem;
 import org.eclipse.nebula.widgets.opal.roundedtoolbar.RoundedToolbar;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Menu;
+import org.eclipse.swt.widgets.MenuItem;
 import org.eclipse.swt.widgets.Shell;
 
 /**
@@ -100,7 +106,10 @@ public class RoundedToolbarSnippet {
 
 		new Label(shell, SWT.NONE).setText("Radio button behaviour (no button drawned)");
 		createRadioButtons(shell, false, false);
-
+		
+		// MENU
+		new Label(shell, SWT.NONE).setText("Menu buttons");
+		createMenuBar(shell);
 		shell.open();
 		while (!shell.isDisposed()) {
 			if (!display.readAndDispatch()) {
@@ -121,6 +130,61 @@ public class RoundedToolbarSnippet {
 
 		display.dispose();
 
+	}
+
+	private static RoundedToolbar createMenuBar(Shell shell) {
+
+		final RoundedToolbar roundedToolBar = new RoundedToolbar(shell, SWT.NONE);
+		final RoundedToolItem item1 = new RoundedToolItem(roundedToolBar, SWT.DROP_DOWN);
+		item1.setText("Menu Toolbar Item");
+		item1.setMenuCreator(new IMenuCreator() {
+
+			private Menu menu;
+
+			@Override
+			public void dispose() {
+
+				if(menu != null) {
+					menu.dispose();
+					menu = null;
+				}
+			}
+
+			@Override
+			public Menu getMenu(Control parent) {
+
+				if(menu == null) {
+					menu = new Menu(parent);
+					for(int i = 1; i <= 3; i++) {
+						MenuItem menuItem = new MenuItem(menu, SWT.NONE);
+						String string = "Item " + i;
+						menuItem.setText(string);
+						menuItem.addSelectionListener(new SelectionListener() {
+
+							@Override
+							public void widgetSelected(SelectionEvent e) {
+
+								item1.setText(string);
+							}
+
+							@Override
+							public void widgetDefaultSelected(SelectionEvent e) {
+
+							}
+						});
+					}
+					parent.addDisposeListener(e -> dispose());
+				}
+				return menu;
+			}
+
+			@Override
+			public Menu getMenu(Menu parent) {
+
+				return null;
+			}
+		});
+		return roundedToolBar;
 	}
 
 	private static void createToggleButtons(final Shell shell) {

--- a/widgets/opal/roundedtoolbar/org.eclipse.nebula.widgets.opal.roundedtoolbar/.classpath
+++ b/widgets/opal/roundedtoolbar/org.eclipse.nebula.widgets.opal.roundedtoolbar/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/widgets/opal/roundedtoolbar/org.eclipse.nebula.widgets.opal.roundedtoolbar/.settings/org.eclipse.jdt.core.prefs
+++ b/widgets/opal/roundedtoolbar/org.eclipse.nebula.widgets.opal.roundedtoolbar/.settings/org.eclipse.jdt.core.prefs
@@ -1,10 +1,10 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
-org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
+org.eclipse.jdt.core.compiler.compliance=17
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
-org.eclipse.jdt.core.compiler.source=11
+org.eclipse.jdt.core.compiler.source=17

--- a/widgets/opal/roundedtoolbar/org.eclipse.nebula.widgets.opal.roundedtoolbar/META-INF/MANIFEST.MF
+++ b/widgets/opal/roundedtoolbar/org.eclipse.nebula.widgets.opal.roundedtoolbar/META-INF/MANIFEST.MF
@@ -4,8 +4,9 @@ Bundle-Name: Nebula Opal Rounded Toolbar
 Bundle-SymbolicName: org.eclipse.nebula.widgets.opal.roundedtoolbar
 Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Eclipse Nebula
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.nebula.widgets.opal.commons;bundle-version="1.0.0";visibility:=reexport,
  org.eclipse.swt
 Export-Package: org.eclipse.nebula.widgets.opal.roundedtoolbar
 Automatic-Module-Name: org.eclipse.nebula.widgets.opal.roundedtoolbar
+Import-Package: org.eclipse.jface.action

--- a/widgets/opal/roundedtoolbar/org.eclipse.nebula.widgets.opal.roundedtoolbar/src/org/eclipse/nebula/widgets/opal/roundedtoolbar/RoundedToolItem.java
+++ b/widgets/opal/roundedtoolbar/org.eclipse.nebula.widgets.opal.roundedtoolbar/src/org/eclipse/nebula/widgets/opal/roundedtoolbar/RoundedToolItem.java
@@ -14,6 +14,7 @@ package org.eclipse.nebula.widgets.opal.roundedtoolbar;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
+import org.eclipse.jface.action.IMenuCreator;
 import org.eclipse.nebula.widgets.opal.commons.AdvancedPath;
 import org.eclipse.nebula.widgets.opal.commons.SWTGraphicUtil;
 import org.eclipse.swt.SWT;
@@ -72,6 +73,7 @@ public class RoundedToolItem extends Item {
 	private int toolbarHeight;
 	private boolean isLast;
 	private final boolean hideSelection;
+	IMenuCreator creator;
 
 	/**
 	 * Constructs a new instance of this class given its parent (which must be a
@@ -1069,6 +1071,11 @@ public class RoundedToolItem extends Item {
 
 	void forceSelection(boolean newSelection) {
 		selection = newSelection;
+	}
+	
+	public void setMenuCreator(IMenuCreator creator) {
+
+		this.creator = creator;
 	}
 
 }

--- a/widgets/opal/roundedtoolbar/org.eclipse.nebula.widgets.opal.roundedtoolbar/src/org/eclipse/nebula/widgets/opal/roundedtoolbar/RoundedToolbar.java
+++ b/widgets/opal/roundedtoolbar/org.eclipse.nebula.widgets.opal.roundedtoolbar/src/org/eclipse/nebula/widgets/opal/roundedtoolbar/RoundedToolbar.java
@@ -16,10 +16,13 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 
+import org.eclipse.jface.action.IMenuCreator;
 import org.eclipse.nebula.widgets.opal.commons.AdvancedPath;
 import org.eclipse.nebula.widgets.opal.commons.SWTGraphicUtil;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.SWTException;
+import org.eclipse.swt.events.MenuEvent;
+import org.eclipse.swt.events.MenuListener;
 import org.eclipse.swt.events.PaintEvent;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.GC;
@@ -27,6 +30,7 @@ import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.widgets.Canvas;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.Widget;
 
 /**
@@ -151,7 +155,39 @@ public class RoundedToolbar extends Canvas {
 				return;
 			}
 			final RoundedToolItem item = pressedItem.get();
-			if (item.isPushButon()) {
+			if(item.isDropDown()) {
+				IMenuCreator creator = item.creator;
+				if(creator == null) {
+					return;
+				}
+				Menu menu = creator.getMenu(this);
+				if(menu == null) {
+					return;
+				}
+				Rectangle bounds = item.getBounds();
+				Point pt = toDisplay(bounds.x, bounds.y);
+				menu.setLocation(pt.x, pt.y + bounds.height);
+				menu.addMenuListener(new MenuListener() {
+
+					@Override
+					public void menuShown(MenuEvent e) {
+
+					}
+
+					@Override
+					public void menuHidden(MenuEvent e) {
+
+						if(!menu.isDisposed()) {
+							menu.removeMenuListener(this);
+						}
+						item.forceSelection(false);
+						redraw();
+						update();
+					}
+				});
+				item.forceSelection(true);
+				menu.setVisible(true);
+			} else if(item.isPushButon()) {
 				item.forceSelection(true);
 			} else {
 				if (item.isToogleButon()) {


### PR DESCRIPTION
The RoundedToolItem supports the style SWT.DROP_DOWN, but setting the style has no effect and there is no obvious way to supply any menu to the item even though there are some traces in the code the style should actually do something, it therefore feels like the implementation is incomplete.

This now adds a RoundedToolItem#setMenuCreator similar to what JFace supports for actions with a menu.