### PR TITLE
Upgrade Tycho and use stable 2025-03 Eclipse Release in Target Platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ class/
 .metadata/
 releng/org.eclipse.nebula.site/updates/
 build.log
+.tycho.*

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
 	<extension>
 		<groupId>org.eclipse.tycho</groupId>
 		<artifactId>tycho-build</artifactId>
-		<version>4.0.4</version>
+		<version>${tycho-version}</version>
 	</extension>
 </extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,1 @@
+-Dtycho-version=4.0.12

--- a/releng/org.eclipse.nebula.nebula-parent/pom.xml
+++ b/releng/org.eclipse.nebula.nebula-parent/pom.xml
@@ -20,7 +20,6 @@ Contributors:
 	<packaging>pom</packaging>
 
 	<properties>
-		<tycho-version>4.0.4</tycho-version>
 		<tycho-extras-version>${tycho-version}</tycho-extras-version>
 		<mockito-version>5.10.0</mockito-version>
 		<findbugs-version>3.0.5</findbugs-version>
@@ -33,7 +32,7 @@ Contributors:
 		<jacoco-version>0.8.9</jacoco-version>
 		<easymock-version>5.2.0</easymock-version>
 
-		<target-platform>https://download.eclipse.org/releases/milestone</target-platform>
+		<target-platform>https://download.eclipse.org/releases/2025-03</target-platform>
 
 		<maven.compiler.source>17</maven.compiler.source>
 		<maven.compiler.target>17</maven.compiler.target>


### PR DESCRIPTION
Build is currently broken due to RAP increased there version and now takes precedence over real SWT but missing some of the constants and classes.