### PR TITLE
Use minimal latest release repositories for builds

### DIFF
--- a/oomph.setup
+++ b/oomph.setup
@@ -175,7 +175,7 @@
         <repository
             url="https://download.eclipse.org/tools/gef/classic/releases/latest"/>
         <repository
-            url="https://download.eclipse.org/releases/${eclipse.target.platform}"/>
+            url="https://download.eclipse.org/technology/swtbot/releases/latest"/>
       </repositoryList>
     </targlet>
   </setupTask>

--- a/pom.xml
+++ b/pom.xml
@@ -19,33 +19,4 @@ http://www.eclipse.org/legal/epl-v10.html -->
 		<module>releng/org.eclipse.nebula.nebula-parent</module>
 	</modules>
 
-<!-- 
-	<modules>
-		<module>releng/org.eclipse.nebula.site</module>
-	</modules>
-
-	<profiles>
-		<profile>
-			<id>release</id>
-			<activation>
-				<activeByDefault>true</activeByDefault>
-			</activation>
-			<modules>
-				<module>releng/org.eclipse.nebula.nebula-release</module>
-			</modules>
-		</profile>
-		<profile>
-			<id>incubation</id>
-			<modules>
-				<module>releng/org.eclipse.nebula.nebula-incubation</module>
-			</modules>
-		</profile>
-		<profile>
-			<id>promote</id>
-			<modules>
-				<module>releng/org.eclipse.nebula.site/promotion</module>
-			</modules>
-		</profile>
-	</profiles>
--->
 </project>

--- a/releng/org.eclipse.nebula.nebula-parent/pom.xml
+++ b/releng/org.eclipse.nebula.nebula-parent/pom.xml
@@ -26,13 +26,15 @@ Contributors:
 		<map-version>3.6.0</map-version>
 		<mjd-version>3.6.3</mjd-version>
 		<mrp-version>3.3.1</mrp-version>
-		<ejp-version>1.3.3</ejp-version>
+		<ejp-version>1.5.2</ejp-version>
 		<pmd-version>3.9.0</pmd-version>
 		<junit-version>4.13.2</junit-version>
 		<jacoco-version>0.8.9</jacoco-version>
 		<easymock-version>5.2.0</easymock-version>
 
-		<target-platform>https://download.eclipse.org/releases/2025-03</target-platform>
+		<target-platform-platform>https://download.eclipse.org/eclipse/updates/latest</target-platform-platform>
+		<target-platform-gef>https://download.eclipse.org/tools/gef/classic/releases/latest</target-platform-gef>
+		<target-platform-swtbot>https://download.eclipse.org/technology/swtbot/releases/latest</target-platform-swtbot>
 
 		<maven.compiler.source>17</maven.compiler.source>
 		<maven.compiler.target>17</maven.compiler.target>
@@ -267,9 +269,19 @@ Contributors:
 
 	<repositories>
 		<repository>
-			<id>projects</id>
+			<id>target-platform-platform</id>
 			<layout>p2</layout>
-			<url>${target-platform}</url>
+			<url>${target-platform-platform}</url>
+		</repository>
+		<repository>
+			<id>target-platform-gef</id>
+			<layout>p2</layout>
+			<url>${target-platform-gef}</url>
+		</repository>
+		<repository>
+			<id>target-platform-swtbot</id>
+			<layout>p2</layout>
+			<url>${target-platform-swtbot}</url>
 		</repository>
 	</repositories>
 

--- a/widgets/cdatetime/org.eclipse.nebula.widgets.cdatetime.example.e4/META-INF/MANIFEST.MF
+++ b/widgets/cdatetime/org.eclipse.nebula.widgets.cdatetime.example.e4/META-INF/MANIFEST.MF
@@ -20,5 +20,5 @@ Bundle-RequiredExecutionEnvironment: JavaSE-11
 Automatic-Module-Name: org.eclipse.nebula.widgets.cdatetime.example.e4
 Bundle-ActivationPolicy: lazy
 Import-Package: javax.annotation;version="1.0.0",
- org.w3c.dom;version="2.0.0",
- org.w3c.dom.css;version="2.0.0"
+ org.w3c.dom,
+ org.w3c.dom.css

--- a/widgets/cdatetime/org.eclipse.nebula.widgets.cdatetime.tests/META-INF/MANIFEST.MF
+++ b/widgets/cdatetime/org.eclipse.nebula.widgets.cdatetime.tests/META-INF/MANIFEST.MF
@@ -20,6 +20,6 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.nebula.widgets.cdatetime.css
 Import-Package: org.eclipse.e4.ui.css.core.engine,
  org.w3c.css.sac,
- org.w3c.dom;version="2.0.0",
- org.w3c.dom.css;version="2.0.0"
+ org.w3c.dom,
+ org.w3c.dom.css
 Automatic-Module-Name: org.eclipse.nebula.widgets.cdatetime.tests

--- a/widgets/grid/org.eclipse.nebula.widgets.grid.test/META-INF/MANIFEST.MF
+++ b/widgets/grid/org.eclipse.nebula.widgets.grid.test/META-INF/MANIFEST.MF
@@ -4,8 +4,7 @@ Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-SymbolicName: org.eclipse.nebula.widgets.grid.test
 Bundle-Version: 0.3.0.qualifier
-Require-Bundle: org.junit;bundle-version="4.8.2",
- org.eclipse.rap.rwt.testfixture;resolution:=optional
+Require-Bundle: org.junit;bundle-version="4.8.2"
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.eclipse.nebula.widgets.grid

--- a/widgets/pagination/org.eclipse.nebula.widgets.pagination.example/META-INF/MANIFEST.MF
+++ b/widgets/pagination/org.eclipse.nebula.widgets.pagination.example/META-INF/MANIFEST.MF
@@ -5,10 +5,12 @@ Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.nebula.widgets.pagination.example;singleton:=true
 Bundle-Version: 1.0.0.qualifier
+Import-Package: org.eclipse.jface.viewers,
+ org.eclipse.swt,
+ org.eclipse.swt.layout,
+ org.eclipse.swt.widgets
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.nebula.examples;bundle-version="1.0.4",
- org.eclipse.ui;resolution:=optional,
  org.eclipse.core.runtime,
- org.eclipse.nebula.widgets.pagination;bundle-version="1.0.0",
- org.eclipse.rap.ui;bundle-version="1.4.0";resolution:=optional
+ org.eclipse.nebula.widgets.pagination;bundle-version="1.0.0"
 Automatic-Module-Name: org.eclipse.nebula.widgets.pagination.example

--- a/widgets/pagination/org.eclipse.nebula.widgets.pagination.snippets/META-INF/MANIFEST.MF
+++ b/widgets/pagination/org.eclipse.nebula.widgets.pagination.snippets/META-INF/MANIFEST.MF
@@ -5,9 +5,13 @@ Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.nebula.widgets.pagination.snippets
 Bundle-Version: 1.0.0.qualifier
-Require-Bundle: org.eclipse.swt,
- org.eclipse.nebula.widgets.pagination;bundle-version="1.0.0",
- org.eclipse.jface
+Import-Package: org.eclipse.jface.viewers,
+ org.eclipse.swt,
+ org.eclipse.swt.custom,
+ org.eclipse.swt.graphics,
+ org.eclipse.swt.layout,
+ org.eclipse.swt.widgets
+Require-Bundle: org.eclipse.nebula.widgets.pagination;bundle-version="1.0.0"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Automatic-Module-Name: org.eclipse.nebula.widgets.pagination.snippets

--- a/widgets/pagination/org.eclipse.nebula.widgets.pagination/META-INF/MANIFEST.MF
+++ b/widgets/pagination/org.eclipse.nebula.widgets.pagination/META-INF/MANIFEST.MF
@@ -15,12 +15,13 @@ Export-Package: org.eclipse.nebula.widgets.pagination,
  org.eclipse.nebula.widgets.pagination.table.forms,
  org.eclipse.nebula.widgets.pagination.tree,
  org.eclipse.nebula.widgets.pagination.tree.forms
-Require-Bundle: org.eclipse.core.runtime,
- org.eclipse.swt;resolution:=optional,
- org.eclipse.ui.forms;resolution:=optional,
- org.eclipse.rap.rwt;resolution:=optional,
- org.eclipse.rap.ui.forms;resolution:=optional,
- org.eclipse.jface;resolution:=optional,
- org.eclipse.rap.jface;resolution:=optional
+Import-Package: org.eclipse.jface.resource,
+ org.eclipse.jface.viewers,
+ org.eclipse.swt,
+ org.eclipse.swt.events,
+ org.eclipse.swt.graphics,
+ org.eclipse.swt.layout,
+ org.eclipse.swt.widgets
+Require-Bundle: org.eclipse.core.runtime
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Automatic-Module-Name: org.eclipse.nebula.widgets.pagination

--- a/widgets/pagination/org.eclipse.nebula.widgets.pagination/src/org/eclipse/nebula/widgets/pagination/renderers/pagesize/PageSizeComboRenderer.java
+++ b/widgets/pagination/org.eclipse.nebula.widgets.pagination/src/org/eclipse/nebula/widgets/pagination/renderers/pagesize/PageSizeComboRenderer.java
@@ -44,13 +44,7 @@ public class PageSizeComboRenderer extends
 		AbstractPageControllerComposite implements
 		SelectionListener {
 
-	private static class InternalLabelProvider extends LabelProvider {
-		private static final ILabelProvider INSTANCE = new InternalLabelProvider();
-
-		public static ILabelProvider getInstance() {
-			return INSTANCE;
-		}
-	}
+	private static final ILabelProvider INSTANCE = new LabelProvider();
 
 	private ComboViewer comboViewer;
 	private Label itemsPerPageLabel;
@@ -120,7 +114,7 @@ public class PageSizeComboRenderer extends
 
 		comboViewer = new ComboViewer(parent, SWT.READ_ONLY);
 		comboViewer.setContentProvider(ArrayContentProvider.getInstance());
-		comboViewer.setLabelProvider(InternalLabelProvider.getInstance());
+		comboViewer.setLabelProvider(INSTANCE);
 		comboViewer.getCombo().setLayoutData(
 				new GridData(GridData.FILL_HORIZONTAL));
 		comboViewer.getCombo().addSelectionListener(this);

--- a/widgets/picture/org.eclipse.nebula.widgets.picture/META-INF/MANIFEST.MF
+++ b/widgets/picture/org.eclipse.nebula.widgets.picture/META-INF/MANIFEST.MF
@@ -7,10 +7,9 @@ Bundle-SymbolicName: org.eclipse.nebula.widgets.picture
 Bundle-Version: 1.0.0.qualifier
 Export-Package: org.eclipse.nebula.widgets.picture,
  org.eclipse.nebula.widgets.picture.forms
+Import-Package: org.eclipse.swt,
+ org.eclipse.swt.graphics,
+ org.eclipse.swt.layout,
+ org.eclipse.swt.widgets
 Bundle-RequiredExecutionEnvironment: JavaSE-11
-Require-Bundle: org.eclipse.swt;resolution:=optional,
- org.eclipse.ui.forms;resolution:=optional,
- org.eclipse.rap.rwt;resolution:=optional,
- org.eclipse.rap.ui.forms;resolution:=optional,
- org.eclipse.rap.filedialog;resolution:=optional
 Automatic-Module-Name: org.eclipse.nebula.widgets.picture

--- a/widgets/richtext/org.eclipse.nebula.widgets.richtext.example/META-INF/MANIFEST.MF
+++ b/widgets/richtext/org.eclipse.nebula.widgets.richtext.example/META-INF/MANIFEST.MF
@@ -5,8 +5,7 @@ Bundle-SymbolicName: org.eclipse.nebula.widgets.richtext.example
 Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
-Require-Bundle: org.apache.commons.logging;bundle-version="1.0.4",
- org.eclipse.jface;bundle-version="3.10.1",
+Require-Bundle: org.eclipse.jface;bundle-version="3.10.1",
  org.eclipse.nebula.widgets.richtext;bundle-version="1.0.0"
 Export-Package: org.eclipse.nebula.widgets.richtext.example
 Automatic-Module-Name: org.eclipse.nebula.widgets.richtext.example

--- a/widgets/tablecombo/org.eclipse.nebula.widgets.tablecombo.test/META-INF/MANIFEST.MF
+++ b/widgets/tablecombo/org.eclipse.nebula.widgets.tablecombo.test/META-INF/MANIFEST.MF
@@ -9,6 +9,5 @@ Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.junit,
  org.eclipse.swt,
  org.eclipse.swtbot.go,
- org.eclipse.core.runtime;bundle-version="3.12.0",
- org.apache.log4j;bundle-version="1.2.15"
+ org.eclipse.core.runtime;bundle-version="3.12.0"
 Automatic-Module-Name: org.eclipse.nebula.widgets.tablecombo.test


### PR DESCRIPTION
- The primary goal is to ensure that we don't unintentionally pick up RAP/RWT dependencies from the SimRel repository.
- Make the corresponding changes to the URLs used for the Oomph setup.
- Update the jar signer version to 1.5.2.
- Don't use versions for org.w3c.dom package imports so they can resolve to the JDK.
- Remove bogus logging dependencies.
- Avoid all bundle imports referencing RWT or RAP; use package imports instead.