### PR TITLE
Create Colors without a display

### DIFF
--- a/widgets/grid/org.eclipse.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/Grid.java
+++ b/widgets/grid/org.eclipse.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/Grid.java
@@ -132,8 +132,8 @@ public class Grid extends Canvas {
 	 * Object holding the visible range
 	 */
 	public static class GridVisibleRange {
-		private GridItem[] items = new GridItem[0];
-		private GridColumn[] columns = new GridColumn[0];
+		private GridItem[] items = {};
+		private GridColumn[] columns = {};
 
 		/**
 		 * @return the current items shown
@@ -310,7 +310,7 @@ public class Grid extends Canvas {
 	 */
 	private final List<GridColumn> displayOrderedColumns = new ArrayList<>();
 
-	private GridColumnGroup[] columnGroups = new GridColumnGroup[0];
+	private GridColumnGroup[] columnGroups = {};
 
 	/**
 	 * Renderer to paint the top left area when both column and row headers are
@@ -866,7 +866,7 @@ public class Grid extends Canvas {
 
 		final RGB cellSel = blend(sel, white, 50);
 
-		cellHeaderSelectionBackground = new Color(getDisplay(), cellSel);
+		cellHeaderSelectionBackground = new Color(cellSel);
 
 		setDragDetect(false);
 	}

--- a/widgets/grid/org.eclipse.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/internal/win7/Win7PaletteProvider.java
+++ b/widgets/grid/org.eclipse.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/internal/win7/Win7PaletteProvider.java
@@ -20,7 +20,7 @@ public class Win7PaletteProvider {
 	 */
 	public static final Integer NORMAL_GRID_COLUMN_HEADER = new Integer(0);
 
-	private static final Object[] NORMAL_GRID_COLUMN_HEADER_RGB = new Object[]{
+	private static final Object[] NORMAL_GRID_COLUMN_HEADER_RGB = {
 		new Integer(SWT.COLOR_WHITE),
 		new Integer(SWT.COLOR_WHITE),
 		new Integer(SWT.COLOR_WHITE),
@@ -44,7 +44,7 @@ public class Win7PaletteProvider {
 	 */
 	public static final Integer HOVER_GRID_COLUMN_HEADER = new Integer(1);
 
-	private static final Object[] HOVER_GRID_COLUMN_HEADER_RGB = new Object[]{
+	private static final Object[] HOVER_GRID_COLUMN_HEADER_RGB = {
 		new Integer(SWT.COLOR_WHITE),
         new RGB(136,203,235),
         new RGB(227,247,255),
@@ -68,7 +68,7 @@ public class Win7PaletteProvider {
 	 */
 	public static final Integer MOUSEDOWN_GRID_COLUMN_HEADER = new Integer(3);
 
-	private static final Object[] MOUSEDOWN_GRID_COLUMN_HEADER_RGB = new Object[]{
+	private static final Object[] MOUSEDOWN_GRID_COLUMN_HEADER_RGB = {
 		new Integer(SWT.COLOR_WHITE),
         new RGB(122,158,177),
         new RGB(188,228,249),
@@ -93,7 +93,7 @@ public class Win7PaletteProvider {
 	 */
 	public static final Integer SELECTED_GRID_COLUMN_HEADER = new Integer(3);
 
-	private static final Object[] SELECTED_GRID_COLUMN_HEADER_RGB = new Object[]{
+	private static final Object[] SELECTED_GRID_COLUMN_HEADER_RGB = {
 		new Integer(SWT.COLOR_WHITE),
         new RGB(150,217,249),
         new RGB(242,249,252),
@@ -118,7 +118,7 @@ public class Win7PaletteProvider {
 	 */
 	public static final Integer SHADOW_GRID_COLUMN_HEADER = new Integer(4);
 
-	private static final Object[] SHADOW_GRID_COLUMN_HEADER_RGB = new Object[]{
+	private static final Object[] SHADOW_GRID_COLUMN_HEADER_RGB = {
         new RGB(134,163,178),
         new RGB(170,206,225)
 	};
@@ -126,7 +126,7 @@ public class Win7PaletteProvider {
 	/**
 	 * Pool of palettes
 	 */
-    private Map<Integer, Palette> palettes = new HashMap<>();
+    private final Map<Integer, Palette> palettes = new HashMap<>();
 
     /**
      * Dispose the
@@ -153,8 +153,9 @@ public class Win7PaletteProvider {
      */
     public Palette getPalette(Display display, Integer type){
     	Palette palette = palettes.get(type);
-        if ( palette != null )
-            return palette;
+        if ( palette != null ) {
+			return palette;
+		}
 
         //create the palette
         if ( type == NORMAL_GRID_COLUMN_HEADER ){
@@ -186,7 +187,7 @@ public class Win7PaletteProvider {
     		} else if ( def[i] instanceof Integer ){
     			colors[i] = (display==null?Display.getCurrent():display).getSystemColor(((Integer)def[i]).intValue());
     		} else {
-    			colors[i] = new Color(display, (RGB)def[i]);
+				colors[i] = new Color((RGB)def[i]);
     		}
     	}
     	return new Palette(type, colors);
@@ -198,8 +199,8 @@ public class Win7PaletteProvider {
      */
     public class Palette {
 
-    	private Integer type;
-    	private Color[] colors = new Color[]{};
+    	private final Integer type;
+    	private Color[] colors = {};
 
     	/**
     	 * @param type
@@ -230,8 +231,9 @@ public class Win7PaletteProvider {
     	public void dispose(){
     		if ( colors != null ){
 	    		for ( int i = 0 ; i < colors.length ; i++ ){
-	    			if ( colors[i] != null )
-	    				colors[i].dispose();
+	    			if ( colors[i] != null ) {
+						colors[i].dispose();
+					}
 	    		}
     		}
     	}

--- a/widgets/opal/commons/org.eclipse.nebula.widgets.opal.commons/src/org/eclipse/nebula/widgets/opal/commons/HTMLStyledTextParser.java
+++ b/widgets/opal/commons/org.eclipse.nebula.widgets.opal.commons/src/org/eclipse/nebula/widgets/opal/commons/HTMLStyledTextParser.java
@@ -51,14 +51,14 @@ public class HTMLStyledTextParser {
 	 */
 	HTMLStyledTextParser(final StyledText styledText) {
 		this.styledText = styledText;
-		listOfStyles = new ArrayList<StyleRange>();
-		stack = new LinkedList<StyleRange>();
+		listOfStyles = new ArrayList<>();
+		stack = new LinkedList<>();
 		final FontData data = styledText.getFont().getFontData()[0];
 		defaultHeight = data.getHeight();
 	}
 
 	private static Map<String, Integer[]> initHTMLCode() {
-		final Map<String, Integer[]> map = new HashMap<String, Integer[]>();
+		final Map<String, Integer[]> map = new HashMap<>();
 
 		map.put("aliceblue", new Integer[] { 240, 248, 255 });
 		map.put("antiquewhite", new Integer[] { 250, 235, 215 });
@@ -320,7 +320,7 @@ public class HTMLStyledTextParser {
 			return;
 		}
 
-		final String[] acceptedClosingTags = new String[] { "/b", "/i", "/u", "/size", "/color", "/backgroundcolor" };
+		final String[] acceptedClosingTags = { "/b", "/i", "/u", "/size", "/color", "/backgroundcolor" };
 		for (final String closingTag : acceptedClosingTags) {
 			if (closingTag.equals(tag)) {
 				processEndTag(closingTag);
@@ -468,11 +468,7 @@ public class HTMLStyledTextParser {
 				blue = rgb[2];
 			}
 		}
-		final Color color = new Color(styledText.getDisplay(), red, green, blue);
-		styledText.addListener(SWT.Dispose, e -> {
-			color.dispose();
-		});
-		return color;
+		return new Color(red, green, blue);
 	}
 
 	private void processBeginBackgroundColor() {

--- a/widgets/opal/commons/org.eclipse.nebula.widgets.opal.commons/src/org/eclipse/nebula/widgets/opal/commons/SWTGraphicUtil.java
+++ b/widgets/opal/commons/org.eclipse.nebula.widgets.opal.commons/src/org/eclipse/nebula/widgets/opal/commons/SWTGraphicUtil.java
@@ -89,14 +89,8 @@ public class SWTGraphicUtil {
 	 * @return the color
 	 */
 	public static Color getColorSafely(final int r, final int g, final int b) {
-		final Display display = Display.getCurrent();
-		final Color color = new Color(display, r, g, b);
-		display.addListener(SWT.Dispose, e -> {
-			if (!color.isDisposed()) {
-				color.dispose();
-			}
-		});
-		return color;
+
+		return new Color(r, g, b);
 	}
 
 	/**
@@ -552,9 +546,8 @@ public class SWTGraphicUtil {
 	 * @return a color that will be disposed when <code>control</code> is disposed
 	 */
 	public static Color getDefaultColor(final Control control, final int red, final int green, final int blue) {
-		final Color defaultColor = new Color(control.getDisplay(), red, green, blue);
-		addDisposer(control, defaultColor);
-		return defaultColor;
+
+		return new Color(red, green, blue);
 	}
 
 	/**

--- a/widgets/opal/roundedtoolbar/org.eclipse.nebula.widgets.opal.roundedtoolbar.snippets/src/org/eclipse/nebula/widgets/opal/roundedtoolbar/snippets/RoundedToolbarSnippet.java
+++ b/widgets/opal/roundedtoolbar/org.eclipse.nebula.widgets.opal.roundedtoolbar.snippets/src/org/eclipse/nebula/widgets/opal/roundedtoolbar/snippets/RoundedToolbarSnippet.java
@@ -57,8 +57,8 @@ public class RoundedToolbarSnippet {
 		gridLayout.horizontalSpacing = 20;
 		shell.setLayout(gridLayout);
 
-		grey1 = new Color(display, 211, 211, 211);
-		grey2 = new Color(display, 255, 250, 250);
+		grey1 = new Color(211, 211, 211);
+		grey2 = new Color(255, 250, 250);
 
 		iconBubble1b = new Image(display, RoundedToolbarSnippet.class.getResourceAsStream("icons/bubble1_b.png"));
 		iconBubble1w = new Image(display, RoundedToolbarSnippet.class.getResourceAsStream("icons/bubble1_w.png"));

--- a/widgets/pgroup/org.eclipse.nebula.widgets.pgroup/src/org/eclipse/nebula/widgets/pgroup/FormGroupStrategy.java
+++ b/widgets/pgroup/org.eclipse.nebula.widgets.pgroup/src/org/eclipse/nebula/widgets/pgroup/FormGroupStrategy.java
@@ -37,15 +37,15 @@ public class FormGroupStrategy extends AbstractGroupStrategy
 
     private Color initialBorderColor;
 
-    private int titleTextMargin = 2;
+    private final int titleTextMargin = 2;
 
-    private int betweenSpacing = 6;
+    private final int betweenSpacing = 6;
 
-    private int margin = 0;
+    private final int margin = 0;
 
-    private int vMargin = 2;
+    private final int vMargin = 2;
 
-    private int hMargin = 6;
+    private final int hMargin = 6;
 
     private Color borderColor;
 
@@ -60,27 +60,29 @@ public class FormGroupStrategy extends AbstractGroupStrategy
     /** 
      * @see org.eclipse.nebula.widgets.pgroup.AbstractGroupStrategy#initialize()
      */
-    public void initialize()
+    @Override
+	public void initialize()
     {
         super.initialize();
 
         RGB borderRGB = GraphicUtils.blend(getGroup().getDisplay()
             .getSystemColor(SWT.COLOR_TITLE_INACTIVE_BACKGROUND_GRADIENT).getRGB(), getGroup()
             .getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND).getRGB(), 100);
-        initialBorderColor = new Color(getGroup().getDisplay(), borderRGB);
+		initialBorderColor = new Color(borderRGB);
         borderColor = initialBorderColor;
 
         RGB backRGB = GraphicUtils.blend(getGroup().getDisplay()
             .getSystemColor(SWT.COLOR_TITLE_BACKGROUND_GRADIENT).getRGB(), getGroup().getDisplay()
             .getSystemColor(SWT.COLOR_LIST_BACKGROUND).getRGB(), 40);
-        initialBackColor = new Color(getGroup().getDisplay(), backRGB);
+		initialBackColor = new Color(backRGB);
 
     }
 
     /**
      * @deprecated use constructor with PGroup element instead
      */
-    public FormGroupStrategy() {
+    @Deprecated
+	public FormGroupStrategy() {
     	this(null);
     }
     
@@ -98,7 +100,8 @@ public class FormGroupStrategy extends AbstractGroupStrategy
     /** 
      * @see org.eclipse.nebula.widgets.pgroup.AbstractGroupStrategy#paint(org.eclipse.swt.graphics.GC)
      */
-    public void paint(GC gc)
+    @Override
+	public void paint(GC gc)
     {
         Color back = getGroup().internalGetBackground();
         if (back != null)
@@ -282,25 +285,30 @@ public class FormGroupStrategy extends AbstractGroupStrategy
 
     }
 
-    public Rectangle getToolItemArea() {
+    @Override
+	public Rectangle getToolItemArea() {
     	return toolItemArea;
     }
 
     /** 
      * @see org.eclipse.nebula.widgets.pgroup.AbstractGroupStrategy#isToggleLocation(int, int)
      */
-    public boolean isToggleLocation(int x, int y)
+    @Override
+	public boolean isToggleLocation(int x, int y)
     {
-        if (super.isToggleLocation(x, y))
-            return true;
+        if (super.isToggleLocation(x, y)) {
+			return true;
+		}
 
-        if (getGroup().getToggleRenderer() == null)
-            return false;
+        if (getGroup().getToggleRenderer() == null) {
+			return false;
+		}
 
         Rectangle textBounds = getTextBounds();
         textBounds.width = Math.min(textWidth,textBounds.width);
-        if (textBounds.contains(x, y))
-            return true;
+        if (textBounds.contains(x, y)) {
+			return true;
+		}
 
         return false;
     }
@@ -345,7 +353,8 @@ public class FormGroupStrategy extends AbstractGroupStrategy
     /** 
      * @see org.eclipse.nebula.widgets.pgroup.AbstractGroupStrategy#getClientArea()
      */
-    public Rectangle getClientArea()
+    @Override
+	public Rectangle getClientArea()
     {
         Rectangle area = getGroup().getBounds();
         area.x = margin;
@@ -358,7 +367,8 @@ public class FormGroupStrategy extends AbstractGroupStrategy
     /**
      * {@inheritDoc}
      */
-    public Rectangle computeTrim(int x, int y, int width, int height)
+    @Override
+	public Rectangle computeTrim(int x, int y, int width, int height)
     {
         Rectangle area = new Rectangle(x, y, Math.max(0, width), Math.max(0, height));
         area.x -= margin;
@@ -371,12 +381,15 @@ public class FormGroupStrategy extends AbstractGroupStrategy
     /** 
      * @see org.eclipse.nebula.widgets.pgroup.AbstractGroupStrategy#dispose()
      */
-    public void dispose()
+    @Override
+	public void dispose()
     {
-        if (initialBackColor != null)
-            initialBackColor.dispose();
-        if (initialBorderColor != null)
-            initialBorderColor.dispose();
+        if (initialBackColor != null) {
+			initialBackColor.dispose();
+		}
+        if (initialBorderColor != null) {
+			initialBorderColor.dispose();
+		}
     }
 
     /**
@@ -395,14 +408,16 @@ public class FormGroupStrategy extends AbstractGroupStrategy
         this.borderColor = borderColor;
     }
 
-    public void update()
+    @Override
+	public void update()
     {
         GC gc = new GC(getGroup());
 
         titleHeight = 0;
 
-        if (getGroup().getImage() != null)
-            titleHeight = getGroup().getImage().getBounds().height + (2 * vMargin);
+        if (getGroup().getImage() != null) {
+			titleHeight = getGroup().getImage().getBounds().height + (2 * vMargin);
+		}
 
         if (getGroup().getToggleRenderer() != null)
         {

--- a/widgets/pgroup/org.eclipse.nebula.widgets.pgroup/src/org/eclipse/nebula/widgets/pgroup/internal/GraphicUtils.java
+++ b/widgets/pgroup/org.eclipse.nebula.widgets.pgroup/src/org/eclipse/nebula/widgets/pgroup/internal/GraphicUtils.java
@@ -14,7 +14,6 @@ package org.eclipse.nebula.widgets.pgroup.internal;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.RGB;
-import org.eclipse.swt.widgets.Display;
 
 /**
  * @author chris
@@ -60,20 +59,23 @@ public class GraphicUtils
         {
             if (i == 0)
             {
-                if (outerColor == null)
-                    continue;
+                if (outerColor == null) {
+					continue;
+				}
                 gc.setForeground(outerColor);
             }
             if (i == 1)
             {
-                if (borderColor == null)
-                    continue;
+                if (borderColor == null) {
+					continue;
+				}
                 gc.setForeground(borderColor);
             }
             if (i == 2)
             {
-                if (innerColor == null)
-                    continue;
+                if (innerColor == null) {
+					continue;
+				}
                 gc.setForeground(innerColor);
             }
 
@@ -81,8 +83,9 @@ public class GraphicUtils
             {
                 for (int x2 = 0; x2 < 5; x2++)
                 {
-                    if (corner[line][x2] == i)
-                        gc.drawPoint(x + x2, y + line);
+                    if (corner[line][x2] == i) {
+						gc.drawPoint(x + x2, y + line);
+					}
                 }
             }
         }
@@ -103,23 +106,26 @@ public class GraphicUtils
         final Color oldBackground = gc.getBackground();
         if (gradientColors.length == 1)
         {
-            if (gradientColors[0] != null)
-                gc.setBackground(gradientColors[0]);
+            if (gradientColors[0] != null) {
+				gc.setBackground(gradientColors[0]);
+			}
             gc.fillRectangle(x, y, width, height);
         }
         else
         {
             final Color oldForeground = gc.getForeground();
             Color lastColor = gradientColors[0];
-            if (lastColor == null)
-                lastColor = oldBackground;
+            if (lastColor == null) {
+				lastColor = oldBackground;
+			}
             int pos = 0;
             for (int i = 0; i < gradientPercents.length; ++i)
             {
                 gc.setForeground(lastColor);
                 lastColor = gradientColors[i + 1];
-                if (lastColor == null)
-                    lastColor = oldBackground;
+                if (lastColor == null) {
+					lastColor = oldBackground;
+				}
                 gc.setBackground(lastColor);
                 if (vertical)
                 {
@@ -225,21 +231,23 @@ public class GraphicUtils
 
     public static Color createNewBlendedColor(RGB rgb1, RGB rgb2, int ratio)
     {
-        Color newColor = new Color(Display.getCurrent(), blend(rgb1, rgb2, ratio));
+
+		Color newColor = new Color(blend(rgb1, rgb2, ratio));
         return newColor;
     }
 
     public static Color createNewBlendedColor(Color c1, Color c2, int ratio)
     {
-        Color newColor = new Color(Display.getCurrent(), blend(c1.getRGB(), c2.getRGB(), ratio));
+
+		Color newColor = new Color(blend(c1.getRGB(), c2.getRGB(), ratio));
         return newColor;
     }
 
     public static Color createNewReverseColor(Color c)
     {
-        Color newColor = new Color(Display.getCurrent(), 255 - c.getRed(), 255 - c.getGreen(),
+
+		return new Color(255 - c.getRed(), 255 - c.getGreen(),
                                    255 - c.getBlue());
-        return newColor;
     }
 
     public static RGB saturate(RGB rgb, float saturation)
@@ -247,17 +255,21 @@ public class GraphicUtils
         float[] hsb = java.awt.Color.RGBtoHSB(rgb.red, rgb.green, rgb.blue, null);
 
         hsb[1] += saturation;
-        if (hsb[1] > 1.0f)
-            hsb[1] = 1.0f;
-        if (hsb[1] < 0f)
-            hsb[1] = 0f;
+        if (hsb[1] > 1.0f) {
+			hsb[1] = 1.0f;
+		}
+        if (hsb[1] < 0f) {
+			hsb[1] = 0f;
+		}
 
         hsb[0] += saturation;
-        if (hsb[0] > 1.0f)
-            hsb[0] = 1.0f;
+        if (hsb[0] > 1.0f) {
+			hsb[0] = 1.0f;
+		}
 
-        if (hsb[0] < 0f)
-            hsb[0] = 0f;
+        if (hsb[0] < 0f) {
+			hsb[0] = 0f;
+		}
 
         java.awt.Color awtColor = new java.awt.Color(java.awt.Color
             .HSBtoRGB(hsb[0], hsb[1], hsb[2]));
@@ -267,6 +279,6 @@ public class GraphicUtils
     public static Color createNewSaturatedColor(Color c, float saturation)
     {
         RGB newRGB = saturate(c.getRGB(), saturation);
-        return new Color(Display.getCurrent(), newRGB);
+		return new Color(newRGB);
     }
 }


### PR DESCRIPTION
Since a while now swt allows creating colors without a display. Nebula still uses the old way and attaching dispose listeners that are run needlessly (since colors are no longer need dispose).

This replace all calls to colors with a display by their plain variant without.