### PR TITLE
[rounded toolbar] Add support for setting the border color

### DIFF
--- a/widgets/opal/roundedtoolbar/org.eclipse.nebula.widgets.opal.roundedtoolbar.snippets/src/org/eclipse/nebula/widgets/opal/roundedtoolbar/snippets/RoundedToolbarSnippet.java
+++ b/widgets/opal/roundedtoolbar/org.eclipse.nebula.widgets.opal.roundedtoolbar.snippets/src/org/eclipse/nebula/widgets/opal/roundedtoolbar/snippets/RoundedToolbarSnippet.java
@@ -109,7 +109,9 @@ public class RoundedToolbarSnippet {
 		
 		// MENU
 		new Label(shell, SWT.NONE).setText("Menu buttons");
-		createMenuBar(shell);
+		RoundedToolbar menuBar = createMenuBar(shell);
+		menuBar.setBorderColor(new Color(255, 0, 0));
+		menuBar.setCornerRadius(15);
 		shell.open();
 		while (!shell.isDisposed()) {
 			if (!display.readAndDispatch()) {
@@ -184,6 +186,8 @@ public class RoundedToolbarSnippet {
 				return null;
 			}
 		});
+		final RoundedToolItem item2 = new RoundedToolItem(roundedToolBar, SWT.TOGGLE);
+		item2.setText("Toggle Item");
 		return roundedToolBar;
 	}
 

--- a/widgets/opal/roundedtoolbar/org.eclipse.nebula.widgets.opal.roundedtoolbar/src/org/eclipse/nebula/widgets/opal/roundedtoolbar/RoundedToolItem.java
+++ b/widgets/opal/roundedtoolbar/org.eclipse.nebula.widgets.opal.roundedtoolbar/src/org/eclipse/nebula/widgets/opal/roundedtoolbar/RoundedToolItem.java
@@ -366,7 +366,7 @@ public class RoundedToolItem extends Item {
 	}
 
 	private void drawRightLine(final int x) {
-		gc.setForeground(RoundedToolbar.BORDER_COLOR);
+		gc.setForeground(parentToolbar.borderColor);
 		gc.drawLine(x + getWidth(), 0, x + getWidth(), toolbarHeight);
 	}
 
@@ -796,7 +796,7 @@ public class RoundedToolItem extends Item {
 	 * number will cause that value to be set to zero instead.
 	 * </p>
 	 *
-	 * @param rect the new bounds for the receiver
+	 * @param rectangle the new bounds for the receiver
 	 *
 	 * @exception SWTException
 	 *                <ul>
@@ -1012,7 +1012,7 @@ public class RoundedToolItem extends Item {
 	 * Controls how text will be displayed in the receiver. The argument should
 	 * be one of <code>TOP</code>, <code>BOTTOM</code> or <code>CENTER</code>.
 	 *
-	 * @param alignment the new alignment
+	 * @param verticalAlignment the new alignment
 	 *
 	 * @exception SWTException
 	 *                <ul>

--- a/widgets/opal/roundedtoolbar/org.eclipse.nebula.widgets.opal.roundedtoolbar/src/org/eclipse/nebula/widgets/opal/roundedtoolbar/RoundedToolbar.java
+++ b/widgets/opal/roundedtoolbar/org.eclipse.nebula.widgets.opal.roundedtoolbar/src/org/eclipse/nebula/widgets/opal/roundedtoolbar/RoundedToolbar.java
@@ -60,10 +60,10 @@ public class RoundedToolbar extends Canvas {
 	private int cornerRadius;
 	private static Color START_GRADIENT_COLOR_DEFAULT = SWTGraphicUtil.getColorSafely(245, 245, 245);
 	private static Color END_GRADIENT_COLOR_DEFAULT = SWTGraphicUtil.getColorSafely(185, 185, 185);
-	static Color BORDER_COLOR = SWTGraphicUtil.getColorSafely(66, 66, 66);
 
 	private Color START_GRADIENT_COLOR = START_GRADIENT_COLOR_DEFAULT;
 	private Color END_GRADIENT_COLOR = END_GRADIENT_COLOR_DEFAULT;
+	Color borderColor = new Color(66, 66, 66);
 
 	/**
 	 * Constructs a new instance of this class given its parent and a style
@@ -97,7 +97,7 @@ public class RoundedToolbar extends Canvas {
 	 */
 	public RoundedToolbar(final Composite parent, final int style) {
 		super(parent, style | SWT.DOUBLE_BUFFERED);
-		items = new ArrayList<RoundedToolItem>();
+		items = new ArrayList<>();
 		cornerRadius = 2;
 		addListeners();
 	}
@@ -135,7 +135,7 @@ public class RoundedToolbar extends Canvas {
 	 */
 	public RoundedToolbar(final Composite parent, final int style, Color startGradientColor, Color endGradientColor) {
 		super(parent, style | SWT.DOUBLE_BUFFERED);
-		items = new ArrayList<RoundedToolItem>();
+		items = new ArrayList<>();
 		cornerRadius = 2;
 		addListeners();
 		START_GRADIENT_COLOR = startGradientColor;
@@ -181,8 +181,7 @@ public class RoundedToolbar extends Canvas {
 							menu.removeMenuListener(this);
 						}
 						item.forceSelection(false);
-						redraw();
-						update();
+						repaint();
 					}
 				});
 				item.forceSelection(true);
@@ -197,8 +196,7 @@ public class RoundedToolbar extends Canvas {
 				item.setSelection(!item.getSelection());
 			}
 
-			redraw();
-			update();
+			repaint();
 		});
 
 		addListener(SWT.MouseUp, event -> {
@@ -220,8 +218,7 @@ public class RoundedToolbar extends Canvas {
 					final Boolean value = (Boolean) getData(LAST_TOGGLE_BUTTON_SELECTED_STATE);
 					lastToggleButtonSelected.forceSelection(value);
 					clearLastToggleButtonInfo();
-					redraw();
-					update();
+					repaint();
 					return;
 				}
 
@@ -239,8 +236,7 @@ public class RoundedToolbar extends Canvas {
 					}
 				}
 			}
-			redraw();
-			update();
+			repaint();
 		});
 		addListener(SWT.MouseHover, event -> {
 			final Optional<RoundedToolItem> previouslySelectedItem = items.stream()//
@@ -274,8 +270,7 @@ public class RoundedToolbar extends Canvas {
 			}
 			clearLastToggleButtonInfo();
 			if (needRedraw) {
-				redraw();
-				update();
+				repaint();
 			}
 		});
 
@@ -477,7 +472,7 @@ public class RoundedToolbar extends Canvas {
 		gc.setBackground(END_GRADIENT_COLOR);
 		gc.fillGradientRectangle(0, 0, width, height, true);
 
-		gc.setForeground(BORDER_COLOR);
+		gc.setForeground(borderColor);
 		gc.drawRoundRectangle(0, 0, width - 1, height - 1, cornerRadius, cornerRadius);
 
 		gc.setClipping((Rectangle) null);
@@ -494,12 +489,38 @@ public class RoundedToolbar extends Canvas {
 		items.remove(roundedToolItem);
 	}
 
+	private void repaint() {
+		redraw();
+		update();
+	}
+
 	/**
 	 * @param cornerRadius new corner radius
 	 */
 	public void setCornerRadius(final int cornerRadius) {
 		checkWidget();
 		this.cornerRadius = cornerRadius;
+	}
+
+	/**
+	 * 
+	 * @return the color used to draw borders in the toolbar
+	 */
+	public Color getBorderColor() {
+		checkWidget();
+		return borderColor;
+	}
+
+	/**
+	 * Set the color used to draw borders on the toolbar
+	 * 
+	 * @param borderColor
+	 *                        the new border color
+	 */
+	public void setBorderColor(Color borderColor) {
+		checkWidget();
+		this.borderColor = borderColor;
+		repaint();
 	}
 
 }


### PR DESCRIPTION
Currently one can not control the color of the border drawn around toolbar items.

This now adds a way to set the border color for a toolbar to any color.

Screenshot from the snippet:
![grafik](https://github.com/user-attachments/assets/7c0197a7-e1d8-47a5-af90-2f76c130bf01)
