### PR TITLE
[rounded toolbar] Allow setting the active color of the toolbar

### DIFF
--- a/widgets/opal/roundedtoolbar/org.eclipse.nebula.widgets.opal.roundedtoolbar.snippets/src/org/eclipse/nebula/widgets/opal/roundedtoolbar/snippets/RoundedToolbarSnippet.java
+++ b/widgets/opal/roundedtoolbar/org.eclipse.nebula.widgets.opal.roundedtoolbar.snippets/src/org/eclipse/nebula/widgets/opal/roundedtoolbar/snippets/RoundedToolbarSnippet.java
@@ -14,6 +14,7 @@
 package org.eclipse.nebula.widgets.opal.roundedtoolbar.snippets;
 
 import org.eclipse.jface.action.IMenuCreator;
+import org.eclipse.nebula.widgets.opal.roundedtoolbar.GradientColor;
 import org.eclipse.nebula.widgets.opal.roundedtoolbar.RoundedToolItem;
 import org.eclipse.nebula.widgets.opal.roundedtoolbar.RoundedToolbar;
 import org.eclipse.swt.SWT;
@@ -110,6 +111,7 @@ public class RoundedToolbarSnippet {
 		// MENU
 		new Label(shell, SWT.NONE).setText("Menu buttons");
 		RoundedToolbar menuBar = createMenuBar(shell);
+		menuBar.setActiveGradientColor(new GradientColor(display.getSystemColor(SWT.COLOR_CYAN), display.getSystemColor(SWT.COLOR_DARK_BLUE)));
 		menuBar.setBorderColor(new Color(255, 0, 0));
 		menuBar.setCornerRadius(15);
 		shell.open();

--- a/widgets/opal/roundedtoolbar/org.eclipse.nebula.widgets.opal.roundedtoolbar/src/org/eclipse/nebula/widgets/opal/roundedtoolbar/GradientColor.java
+++ b/widgets/opal/roundedtoolbar/org.eclipse.nebula.widgets.opal.roundedtoolbar/src/org/eclipse/nebula/widgets/opal/roundedtoolbar/GradientColor.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Christoph Läubrich.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors: Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.nebula.widgets.opal.roundedtoolbar;
+
+import org.eclipse.swt.graphics.Color;
+
+/**
+ * Represents a gradient color with a start and end
+ */
+public record GradientColor(Color start, Color end) {
+}

--- a/widgets/opal/roundedtoolbar/org.eclipse.nebula.widgets.opal.roundedtoolbar/src/org/eclipse/nebula/widgets/opal/roundedtoolbar/RoundedToolItem.java
+++ b/widgets/opal/roundedtoolbar/org.eclipse.nebula.widgets.opal.roundedtoolbar/src/org/eclipse/nebula/widgets/opal/roundedtoolbar/RoundedToolItem.java
@@ -16,7 +16,6 @@ import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.eclipse.jface.action.IMenuCreator;
 import org.eclipse.nebula.widgets.opal.commons.AdvancedPath;
-import org.eclipse.nebula.widgets.opal.commons.SWTGraphicUtil;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.SWTException;
 import org.eclipse.swt.events.SelectionAdapter;
@@ -52,9 +51,6 @@ import org.eclipse.swt.widgets.Widget;
 public class RoundedToolItem extends Item {
 
 	private static final int MARGIN = 4;
-	private static Color START_GRADIENT_COLOR = SWTGraphicUtil.getColorSafely(70, 70, 70);
-	private static Color END_GRADIENT_COLOR = SWTGraphicUtil.getColorSafely(116, 116, 116);
-
 	private final RoundedToolbar parentToolbar;
 	private final List<SelectionListener> selectionListeners;
 	private Rectangle bounds;
@@ -151,7 +147,7 @@ public class RoundedToolItem extends Item {
 		enabled = true;
 		alignment = SWT.CENTER;
 		verticalAlignment = SWT.CENTER;
-		selectionListeners = new CopyOnWriteArrayList<SelectionListener>();
+		selectionListeners = new CopyOnWriteArrayList<>();
 		width = -1;
 		height = -1;
 		hideSelection = (parent.getStyle() & SWT.HIDE_SELECTION) == SWT.HIDE_SELECTION;
@@ -357,8 +353,8 @@ public class RoundedToolItem extends Item {
 
 		gc.setClipping(path);
 
-		gc.setForeground(START_GRADIENT_COLOR);
-		gc.setBackground(END_GRADIENT_COLOR);
+		gc.setForeground(parentToolbar.activeGradientColor.start());
+		gc.setBackground(parentToolbar.activeGradientColor.end());
 		gc.fillGradientRectangle(x, 0, width + parentToolbar.getCornerRadius(), toolbarHeight, true);
 
 		gc.setClipping((Rectangle) null);

--- a/widgets/opal/roundedtoolbar/org.eclipse.nebula.widgets.opal.roundedtoolbar/src/org/eclipse/nebula/widgets/opal/roundedtoolbar/RoundedToolbar.java
+++ b/widgets/opal/roundedtoolbar/org.eclipse.nebula.widgets.opal.roundedtoolbar/src/org/eclipse/nebula/widgets/opal/roundedtoolbar/RoundedToolbar.java
@@ -14,11 +14,11 @@ package org.eclipse.nebula.widgets.opal.roundedtoolbar;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import org.eclipse.jface.action.IMenuCreator;
 import org.eclipse.nebula.widgets.opal.commons.AdvancedPath;
-import org.eclipse.nebula.widgets.opal.commons.SWTGraphicUtil;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.SWTException;
 import org.eclipse.swt.events.MenuEvent;
@@ -56,13 +56,15 @@ public class RoundedToolbar extends Canvas {
 	private static final String LAST_TOGGLE_BUTTON_SELECTED = RoundedToolbar.class.toString() + "_LAST_TOGGLE_BUTTON_SELECTED";
 	private static final String LAST_TOGGLE_BUTTON_SELECTED_STATE = RoundedToolbar.class.toString() + "_LAST_TOGGLE_BUTTON_SELECTED_STATE";
 
-	private final List<RoundedToolItem> items;
-	private int cornerRadius;
-	private static Color START_GRADIENT_COLOR_DEFAULT = SWTGraphicUtil.getColorSafely(245, 245, 245);
-	private static Color END_GRADIENT_COLOR_DEFAULT = SWTGraphicUtil.getColorSafely(185, 185, 185);
+	private final List<RoundedToolItem> items = new ArrayList<>();
+	private int cornerRadius = 2;
+	private static final GradientColor DEFAULT_GRADIENT_COLOR = new GradientColor(new Color(245, 245, 245),
+			new Color(185, 185, 185));
+	private static final GradientColor ACTIVE_GRADIENT_COLOR = new GradientColor(new Color(70, 70, 70),
+			new Color(116, 116, 116));
 
-	private Color START_GRADIENT_COLOR = START_GRADIENT_COLOR_DEFAULT;
-	private Color END_GRADIENT_COLOR = END_GRADIENT_COLOR_DEFAULT;
+	GradientColor defaultGradientColor;
+	GradientColor activeGradientColor = ACTIVE_GRADIENT_COLOR;
 	Color borderColor = new Color(66, 66, 66);
 
 	/**
@@ -97,8 +99,7 @@ public class RoundedToolbar extends Canvas {
 	 */
 	public RoundedToolbar(final Composite parent, final int style) {
 		super(parent, style | SWT.DOUBLE_BUFFERED);
-		items = new ArrayList<>();
-		cornerRadius = 2;
+		defaultGradientColor = DEFAULT_GRADIENT_COLOR;
 		addListeners();
 	}
 
@@ -130,16 +131,14 @@ public class RoundedToolbar extends Canvas {
 	 *                <li>ERROR_INVALID_SUBCLASS - if this class is not an
 	 *                allowed subclass</li>
 	 *                </ul>
-	 *
+	 *@deprecated use default swt-style constructor and setters instead
 	 * @see Widget#getStyle()
 	 */
+	@Deprecated
 	public RoundedToolbar(final Composite parent, final int style, Color startGradientColor, Color endGradientColor) {
 		super(parent, style | SWT.DOUBLE_BUFFERED);
-		items = new ArrayList<>();
-		cornerRadius = 2;
+		defaultGradientColor = new GradientColor(startGradientColor, endGradientColor);
 		addListeners();
-		START_GRADIENT_COLOR = startGradientColor;
-		END_GRADIENT_COLOR = endGradientColor;
 	}
 
 	private void addListeners() {
@@ -468,8 +467,8 @@ public class RoundedToolbar extends Canvas {
 		path.addRoundRectangle(0, 0, width, height, cornerRadius, cornerRadius);
 		gc.setClipping(path);
 
-		gc.setForeground(START_GRADIENT_COLOR);
-		gc.setBackground(END_GRADIENT_COLOR);
+		gc.setForeground(defaultGradientColor.start());
+		gc.setBackground(defaultGradientColor.end());
 		gc.fillGradientRectangle(0, 0, width, height, true);
 
 		gc.setForeground(borderColor);
@@ -477,6 +476,34 @@ public class RoundedToolbar extends Canvas {
 
 		gc.setClipping((Rectangle) null);
 		path.dispose();
+	}
+
+	/**
+	 * Sets the default {@link GradientColor} for this {@link RoundedToolbar}, the
+	 * color is used for the default button state
+	 * 
+	 * @param defaultGradientColor the gradient colors to use
+	 */
+	public void setDefaultGradientColor(GradientColor defaultGradientColor) {
+		checkWidget();
+		if (!Objects.equals(defaultGradientColor, this.defaultGradientColor)) {
+			this.defaultGradientColor = defaultGradientColor;
+			repaint();
+		}
+	}
+
+	/**
+	 * Sets the active {@link GradientColor} for this {@link RoundedToolbar}, the
+	 * color is used when a button is active (e.g. pressed)
+	 * 
+	 * @param activeGradientColor the gradient colors to use
+	 */
+	public void setActiveGradientColor(GradientColor activeGradientColor) {
+		checkWidget();
+		if (!Objects.equals(activeGradientColor, this.activeGradientColor)) {
+			this.activeGradientColor = activeGradientColor;
+			repaint();
+		}
 	}
 
 	/**


### PR DESCRIPTION
Currently it is only possible to change the default color of the toolbar using a rather unusual constructor argument. SWT widget are generally only have one constructor with the parent and the style.

This now deprecates the constructor that was used to init the default color and replace it with a proper getter. Additionally it is now also possible to change the color of the active state (when a button is pressed).

This is how it look like with the adjusted snippet:

![grafik](https://github.com/user-attachments/assets/9d3a0fd0-9165-4e2d-a8c1-593bab93e4db)
