### PR TITLE
Make a disabled SwitchButton appear visually disabled

### DIFF
--- a/widgets/opal/switchbutton/org.eclipse.nebula.widgets.opal.switchbutton.snippets/.classpath
+++ b/widgets/opal/switchbutton/org.eclipse.nebula.widgets.opal.switchbutton.snippets/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/widgets/opal/switchbutton/org.eclipse.nebula.widgets.opal.switchbutton.snippets/.settings/org.eclipse.jdt.core.prefs
+++ b/widgets/opal/switchbutton/org.eclipse.nebula.widgets.opal.switchbutton.snippets/.settings/org.eclipse.jdt.core.prefs
@@ -1,10 +1,10 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
-org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
+org.eclipse.jdt.core.compiler.compliance=17
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
-org.eclipse.jdt.core.compiler.source=11
+org.eclipse.jdt.core.compiler.source=17

--- a/widgets/opal/switchbutton/org.eclipse.nebula.widgets.opal.switchbutton.snippets/META-INF/MANIFEST.MF
+++ b/widgets/opal/switchbutton/org.eclipse.nebula.widgets.opal.switchbutton.snippets/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Nebula Opal Switch Button Snippets
 Bundle-SymbolicName: org.eclipse.nebula.widgets.opal.switchbutton.snippets
 Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Eclipse Nebula
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.nebula.widgets.opal.switchbutton;bundle-version="1.0.0",
  org.eclipse.swt
 Automatic-Module-Name: org.eclipse.nebula.widgets.opal.switchbutton.snippets

--- a/widgets/opal/switchbutton/org.eclipse.nebula.widgets.opal.switchbutton.snippets/src/org/eclipse/nebula/widgets/opal/switchbutton/snippets/SwitchButtonSnippet.java
+++ b/widgets/opal/switchbutton/org.eclipse.nebula.widgets.opal.switchbutton.snippets/src/org/eclipse/nebula/widgets/opal/switchbutton/snippets/SwitchButtonSnippet.java
@@ -51,9 +51,13 @@ public class SwitchButtonSnippet {
 		button2.setText("Default switchButton with border");
 
 		// Disabled
-		final SwitchButton button3 = new SwitchButton(shell, SWT.NONE);
-		button3.setEnabled(false);
-		button3.setText("Default switchButton disabled");
+		final SwitchButton button3Off = new SwitchButton(shell, SWT.NONE);
+		button3Off.setEnabled(false);
+		button3Off.setText("Default switchButton disabled (OFF State)");
+		final SwitchButton button3On = new SwitchButton(shell, SWT.NONE);
+		button3On.setSelection(true);
+		button3On.setEnabled(false);
+		button3On.setText("Default switchButton disabled (ON State)");
 
 		// Without glow effect
 		final SwitchButton button4 = new SwitchButton(shell, SWT.NONE);

--- a/widgets/opal/switchbutton/org.eclipse.nebula.widgets.opal.switchbutton/.classpath
+++ b/widgets/opal/switchbutton/org.eclipse.nebula.widgets.opal.switchbutton/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/widgets/opal/switchbutton/org.eclipse.nebula.widgets.opal.switchbutton/.settings/org.eclipse.jdt.core.prefs
+++ b/widgets/opal/switchbutton/org.eclipse.nebula.widgets.opal.switchbutton/.settings/org.eclipse.jdt.core.prefs
@@ -1,10 +1,10 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
-org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
+org.eclipse.jdt.core.compiler.compliance=17
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
-org.eclipse.jdt.core.compiler.source=11
+org.eclipse.jdt.core.compiler.source=17

--- a/widgets/opal/switchbutton/org.eclipse.nebula.widgets.opal.switchbutton/META-INF/MANIFEST.MF
+++ b/widgets/opal/switchbutton/org.eclipse.nebula.widgets.opal.switchbutton/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Nebula Opal Switch Button Widget
 Bundle-SymbolicName: org.eclipse.nebula.widgets.opal.switchbutton
 Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Eclipse Nebula
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.nebula.widgets.opal.commons;bundle-version="1.0.0";visibility:=reexport,
  org.eclipse.swt;bundle-version="[3.126.0,4.0.0)"
 Export-Package: org.eclipse.nebula.widgets.opal.switchbutton

--- a/widgets/opal/switchbutton/org.eclipse.nebula.widgets.opal.switchbutton/src/org/eclipse/nebula/widgets/opal/switchbutton/SwitchButton.java
+++ b/widgets/opal/switchbutton/org.eclipse.nebula.widgets.opal.switchbutton/src/org/eclipse/nebula/widgets/opal/switchbutton/SwitchButton.java
@@ -242,9 +242,9 @@ public class SwitchButton extends Canvas {
 		} else {
 			gc.drawRectangle(2, 2, buttonSize.x, buttonSize.y);
 		}
-
-		drawRightPart(buttonSize);
-		drawLeftPart(buttonSize);
+		boolean enabled = isEnabled();
+		drawRightPart(buttonSize, enabled);
+		drawLeftPart(buttonSize, enabled);
 		gc.setClipping(getClientArea());
 		drawToggleButton(buttonSize);
 	}
@@ -254,16 +254,26 @@ public class SwitchButton extends Canvas {
 	 *
 	 * @param buttonSize size of the button
 	 */
-	private void drawRightPart(final Point buttonSize) {
-		gc.setForeground(selectedBackgroundColor);
-		gc.setBackground(selectedBackgroundColor);
+	private void drawRightPart(final Point buttonSize, boolean enabled) {
+		if (enabled) {
+			gc.setForeground(selectedBackgroundColor);
+			gc.setBackground(selectedBackgroundColor);
+		} else {
+			Color disabled = gc.getDevice().getSystemColor(SWT.COLOR_TEXT_DISABLED_BACKGROUND);
+			gc.setForeground(disabled);
+			gc.setBackground(disabled);
+		}
 		gc.setClipping(3, 3, buttonSize.x / 2, buttonSize.y - 1);
 		if (round) {
 			gc.fillRoundRectangle(2, 2, buttonSize.x, buttonSize.y, arc, arc);
 		} else {
 			gc.fillRectangle(2, 2, buttonSize.x, buttonSize.y);
 		}
-		gc.setForeground(selectedForegroundColor);
+		if (enabled) {
+			gc.setForeground(selectedForegroundColor);
+		} else {
+			gc.setForeground(gc.getDevice().getSystemColor(SWT.COLOR_WIDGET_DISABLED_FOREGROUND));
+		}
 		final Point textSize = gc.textExtent(textForSelect);
 		gc.drawString(textForSelect, (buttonSize.x / 2 - textSize.x) / 2 + arc, (buttonSize.y - textSize.y) / 2 + arc);
 	}
@@ -273,16 +283,26 @@ public class SwitchButton extends Canvas {
 	 *
 	 * @param buttonSize size of the button
 	 */
-	private void drawLeftPart(final Point buttonSize) {
-		gc.setForeground(unselectedBackgroundColor);
-		gc.setBackground(unselectedBackgroundColor);
+	private void drawLeftPart(final Point buttonSize, boolean enabled) {
+		if (enabled) {
+			gc.setForeground(unselectedBackgroundColor);
+			gc.setBackground(unselectedBackgroundColor);
+		} else {
+			Color disabled = gc.getDevice().getSystemColor(SWT.COLOR_TEXT_DISABLED_BACKGROUND);
+			gc.setForeground(disabled);
+			gc.setBackground(disabled);
+		}
 		gc.setClipping(buttonSize.x / 2 + 3, 3, buttonSize.x / 2, buttonSize.y - 1);
 		if (round) {
 			gc.fillRoundRectangle(2, 2, buttonSize.x, buttonSize.y, arc, arc);
 		} else {
 			gc.fillRectangle(2, 2, buttonSize.x, buttonSize.y);
 		}
-		gc.setForeground(unselectedForegroundColor);
+		if (enabled) {
+			gc.setForeground(unselectedForegroundColor);
+		} else {
+			gc.setForeground(gc.getDevice().getSystemColor(SWT.COLOR_WIDGET_DISABLED_FOREGROUND));
+		}
 		final Point textSize = gc.textExtent(textForUnselect);
 
 		gc.drawString(textForUnselect, buttonSize.x / 2 + (buttonSize.x / 2 - textSize.x) / 2 + arc, //
@@ -571,7 +591,7 @@ public class SwitchButton extends Canvas {
 	}
 
 	/**
-	 * @param the text displayed in the widget
+	 * @param text the text displayed in the widget
 	 * @exception SWTException
 	 *                <ul>
 	 *                <li>ERROR_WIDGET_DISPOSED - if the receiver has been
@@ -698,8 +718,8 @@ public class SwitchButton extends Canvas {
 	}
 
 	/**
-	 * @param the foreground color of the left part of the widget (selection is
-	 *            on)
+	 * @param selectedForegroundColor the foreground color of the left part of the
+	 *                                widget (selection is on)
 	 * @exception SWTException
 	 *                <ul>
 	 *                <li>ERROR_WIDGET_DISPOSED - if the receiver has been
@@ -731,8 +751,8 @@ public class SwitchButton extends Canvas {
 	}
 
 	/**
-	 * @param the background color of the left part of the widget (selection is
-	 *            on)
+	 * @param selectedBackgroundColor the background color of the left part of the
+	 *                                widget (selection is on)
 	 */
 	public void setSelectedBackgroundColor(final Color selectedBackgroundColor) {
 		checkWidget();


### PR DESCRIPTION
Currently the only effect when disabling a switch button is that the user can't change the state anymore, but there is no way to visually distinguish a disabled from an enabled button. This makes the UI feel buggy from the users point of view as the button does not work for an unknown reason.

This now makes the button using the default disabled colors when it is disabled appearing grey like other controls when disabled.

## Before

![grafik](https://github.com/user-attachments/assets/b8613a3d-c440-4c9c-bb80-ab140936eab9)

## After

![grafik](https://github.com/user-attachments/assets/0e06004c-c73d-462a-829f-2ac523e7b829)
