### PR TITLE
[grid] Add support for filling columns

### DIFF
--- a/widgets/grid/org.eclipse.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/GridColumn.java
+++ b/widgets/grid/org.eclipse.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/GridColumn.java
@@ -49,7 +49,7 @@ import org.eclipse.swt.widgets.Item;
  * <p>
  * <dl>
  * <dt><b>Styles:</b></dt>
- * <dd>SWT.LEFT, SWT.RIGHT, SWT.CENTER, SWT.CHECK</dd>
+ * <dd>SWT.LEFT, SWT.RIGHT, SWT.CENTER, SWT.CHECK, SWT.FILL</dd>
  * <dt><b>Events:</b></dt>
  * <dd>Move, Resize, Selection, Show, Hide</dd>
  * </dl>
@@ -195,6 +195,8 @@ public class GridColumn extends Item {
 	private String headerTooltip = null;
 	int index;
 
+	private boolean fill;
+
 	/**
 	 * Constructs a new instance of this class given its parent (which must be a
 	 * <code>Grid</code>) and a style value describing its behavior and
@@ -297,6 +299,10 @@ public class GridColumn extends Item {
 			check = true;
 		}
 
+		if ((style & SWT.FILL) != 0) {
+			fill = true;
+		}
+
 		initHeaderRenderer();
 		initFooterRenderer();
 		initCellRenderer();
@@ -342,6 +348,10 @@ public class GridColumn extends Item {
 
 	private void initFooterRenderer() {
 		footerRenderer.setDisplay(getDisplay());
+	}
+
+	boolean isFill() {
+		return fill;
 	}
 
 	/**
@@ -400,6 +410,13 @@ public class GridColumn extends Item {
 	 */
 	public int getWidth() {
 		checkWidget();
+		return width;
+	}
+
+	int getWidth(int extra) {
+		if (fill) {
+			return width + extra;
+		}
 		return width;
 	}
 

--- a/widgets/grid/org.eclipse.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/GridItem.java
+++ b/widgets/grid/org.eclipse.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/GridItem.java
@@ -495,7 +495,7 @@ public class GridItem extends Item {
 		checkWidget();
 
 		final Point origin = parent.getOrigin(parent.getColumn(columnIndex), this);
-		final Point cellSize = this.getCellSize(columnIndex);
+		final Point cellSize = this.getCellSize(columnIndex, parent.getExtraFill());
 		return new Rectangle(origin.x, origin.y, cellSize.x, cellSize.y);
 	}
 
@@ -541,17 +541,26 @@ public class GridItem extends Item {
 		if (origin.x < 0 && parent.isRowHeaderVisible())
 			return new Rectangle(-1000, -1000, 0, 0);
 
-		Point cellSize = this.getCellSize(columnIndex);
+		Point cellSize = this.getCellSize(columnIndex, parent.getExtraFill());
 
 		return new Rectangle(origin.x, origin.y, cellSize.x, cellSize.y);
 	}
 
 	/**
 	 *
-	 * @param columnIndex
+	 * @param columnIndex index of the column to get the cell size
 	 * @return width and height
 	 */
 	protected Point getCellSize(int columnIndex) {
+		return getCellSize(columnIndex, parent.getExtraFill());
+	}
+	/**
+	 *
+	 * @param columnIndex index of the column to get the cell size
+	 * @param extraFill any extra width that should be applied to columns that have fill property
+	 * @return width and height
+	 */
+	protected Point getCellSize(int columnIndex, int extraFill) {
 		/* width */
 		int width = 0;
 
@@ -571,7 +580,7 @@ public class GridItem extends Item {
 				break;
 			}
 			int nextColumnIndex = columnOrder[visualColumnIndex + i];
-			width += parent.getColumn(nextColumnIndex).getWidth();
+			width += parent.getColumn(nextColumnIndex).getWidth(extraFill);
 		}
 
 		/* height */


### PR DESCRIPTION
Currently if the view port of the grid is larger than the sum of its columns width we currently show a gray empty space (or white in the content). This does not only look like wasted space but often there actually is some content that would deserve more space if there is any.

This now adds support for a new style on GridColumn (`SWT.FILL`) that marks the column as one that wants to consume extra available space. These column now gets stretched if there is space left, if more than one such column exists the space is distributed equally between them.