### PR TITLE
Update oomph.setup to configure a Java 21 JRE

### DIFF
--- a/oomph.setup
+++ b/oomph.setup
@@ -76,8 +76,8 @@
   </setupTask>
   <setupTask
       xsi:type="jdt:JRETask"
-      version="JavaSE-17"
-      location="${jre.location-17}">
+      version="JavaSE-21"
+      location="${jre.location-21}">
     <description>Define the JRE needed to compile and run the Java projects of ${scope.project.label}</description>
   </setupTask>
   <setupTask
@@ -142,6 +142,12 @@
         <value>remoteURI</value>
       </detail>
     </annotation>
+    <configSections
+        name="branch">
+      <properties
+          key="autoSetupRebase"
+          value="always"/>
+    </configSections>
     <description>${scope.project.label}</description>
   </setupTask>
   <setupTask


### PR DESCRIPTION
- Configure the clone to use rebase for new branches, i.e., for PRs.