### PR TITLE
Avoid copying the GridItem.children array repeatedly

### DIFF
--- a/widgets/grid/org.eclipse.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/Grid.java
+++ b/widgets/grid/org.eclipse.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/Grid.java
@@ -7957,16 +7957,16 @@ public class Grid extends Canvas {
 				index = rootItems.get(index).getRowIndex();
 			}
 		} else if (!root) {
-			if (index >= item.getParentItem().getItems().length || index == -1) {
+			if (index >= item.getParentItem().getItemCount() || index == -1) {
 				GridItem rightMostDescendent = item.getParentItem();
 
-				while (rightMostDescendent.getItems().length > 0) {
-					rightMostDescendent = rightMostDescendent.getItems()[rightMostDescendent.getItems().length - 1];
+				while (rightMostDescendent.getItemCount() > 0) {
+					rightMostDescendent = rightMostDescendent.getItem(rightMostDescendent.getItemCount() - 1);
 				}
 
 				index = rightMostDescendent.getRowIndex() + 1;
 			} else {
-				index = item.getParentItem().getItems()[index].getRowIndex();
+				index = item.getParentItem().getItem(index).getRowIndex();
 			}
 		}
 

--- a/widgets/grid/org.eclipse.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/Grid.java
+++ b/widgets/grid/org.eclipse.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/Grid.java
@@ -7957,7 +7957,7 @@ public class Grid extends Canvas {
 				index = rootItems.get(index).getRowIndex();
 			}
 		} else if (!root) {
-			if (index >= item.getParentItem().getItemCount() || index == -1) {
+			if (index == -1 || index >= item.getParentItem().getItemCount()) {
 				GridItem rightMostDescendent = item.getParentItem();
 
 				while (rightMostDescendent.getItemCount() > 0) {


### PR DESCRIPTION
The GridItem.getItems() method performs a defensive copy. Because newItem() repeatedly invoked getItems(), this creates a quadratic runtime when adding many children to the same node.

Solution: Use GridItem.getItemCount() and GridItem.getItem() where possible.

Most other uses of GridItem.getItems() could be removed by having a GridItem.iterItems() method, which is not covered here