### PR TITLE
Workaround for Race Condition on Creating Browserfunctions for Edge #662

### DIFF
--- a/widgets/richtext/org.eclipse.nebula.widgets.richtext/src/org/eclipse/nebula/widgets/richtext/RichTextEditor.java
+++ b/widgets/richtext/org.eclipse.nebula.widgets.richtext/src/org/eclipse/nebula/widgets/richtext/RichTextEditor.java
@@ -248,40 +248,11 @@ public class RichTextEditor extends Composite {
 
 		browser.setUrl(templateURL.toString());
 
-		browserFunctions.add(new ModifyFunction(browser, "textModified"));
-		browserFunctions.add(new KeyPressedFunction(browser, "keyPressed"));
-		browserFunctions.add(new KeyReleasedFunction(browser, "keyReleased"));
-		browserFunctions.add(new FocusInFunction(browser, "focusIn"));
-		browserFunctions.add(new FocusOutFunction(browser, "focusOut"));
-		browserFunctions.add(new JavaExecutionStartedFunction(browser, "javaExecutionStarted"));
-		browserFunctions.add(new JavaExecutionFinishedFunction(browser, "javaExecutionFinished"));
-		browserFunctions.add(new BrowserFunction(browser, "customizeToolbar") {
-			@Override
-			public Object function(final Object[] arguments) {
-				RichTextEditor.this.editorConfig.customizeToolbar();
-				return super.function(arguments);
-			}
-		});
-		browserFunctions.add(new BrowserFunction(browser, "getAllOptions") {
-			@Override
-			public Object function(final Object[] arguments) {
-				// transform the configuration options map into an Object array
-				// necessary as map is not a supported return value
-				final Map<String, Object> options = RichTextEditor.this.editorConfig.getAllOptions();
-				final Object[] result = new Object[options.size()*2];
-				int i = 0;
-				for (final Map.Entry<String, Object> entry : options.entrySet()) {
-					result[i++] = entry.getKey();
-					result[i++] = entry.getValue() != null ? entry.getValue() : "";
-				}
-				return result;
-			}
-		});
-
 		browser.addProgressListener(new ProgressListener() {
 
 			@Override
 			public void completed(final ProgressEvent event) {
+				createBrowserFunctions();
 				browser.evaluate("initEditor();");
 
 				CKEDITOR_ALT = (Double) browser.evaluate("return getCKEditorALT()");
@@ -365,6 +336,38 @@ public class RichTextEditor extends Composite {
 
 			@Override
 			public void changed(final ProgressEvent event) {
+			}
+		});	
+	}
+
+	private void createBrowserFunctions() {
+		browserFunctions.add(new ModifyFunction(browser, "textModified"));
+		browserFunctions.add(new KeyPressedFunction(browser, "keyPressed"));
+		browserFunctions.add(new KeyReleasedFunction(browser, "keyReleased"));
+		browserFunctions.add(new FocusInFunction(browser, "focusIn"));
+		browserFunctions.add(new FocusOutFunction(browser, "focusOut"));
+		browserFunctions.add(new JavaExecutionStartedFunction(browser, "javaExecutionStarted"));
+		browserFunctions.add(new JavaExecutionFinishedFunction(browser, "javaExecutionFinished"));
+		browserFunctions.add(new BrowserFunction(browser, "customizeToolbar") {
+			@Override
+			public Object function(final Object[] arguments) {
+				RichTextEditor.this.editorConfig.customizeToolbar();
+				return super.function(arguments);
+			}
+		});
+		browserFunctions.add(new BrowserFunction(browser, "getAllOptions") {
+			@Override
+			public Object function(final Object[] arguments) {
+				// transform the configuration options map into an Object array
+				// necessary as map is not a supported return value
+				final Map<String, Object> options = RichTextEditor.this.editorConfig.getAllOptions();
+				final Object[] result = new Object[options.size()*2];
+				int i = 0;
+				for (final Map.Entry<String, Object> entry : options.entrySet()) {
+					result[i++] = entry.getKey();
+					result[i++] = entry.getValue() != null ? entry.getValue() : "";
+				}
+				return result;
 			}
 		});
 	}


### PR DESCRIPTION
On the edge browser engine it can happen that the browser functions registered by the rich text editor are not yet available when the document is parsed. By setting the template url after the browser functions are registered and sleeping the thread a bit the race condition went away.

Addresses: https://github.com/EclipseNebula/nebula/issues/662 See also:
https://github.com/eclipse-platform/eclipse.platform.swt/issues/2449