### PR TITLE
Fix memory leak and font disposal issues in FloatingText widget

### DIFF
--- a/widgets/floatingtext/org.eclipse.nebula.widgets.floatingtext.feature/feature.xml
+++ b/widgets/floatingtext/org.eclipse.nebula.widgets.floatingtext.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.nebula.widgets.floatingtext.feature"
       label="Nebula Floating Text Widget"
-      version="1.0.0.qualifier"
+      version="1.0.1.qualifier"
       provider-name="Eclipse Nebula">
 
    <description url="http://www.eclipse.org/nebula/widgets/floatingtext/floatingtext.php">
@@ -24,16 +24,10 @@ http://www.eclipse.org/legal/epl-v10.html
 
    <plugin
          id="org.eclipse.nebula.widgets.floatingtext"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
    <plugin
          id="org.eclipse.nebula.widgets.floatingtext.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
+         version="0.0.0"/>
 
 </feature>

--- a/widgets/floatingtext/org.eclipse.nebula.widgets.floatingtext.feature/pom.xml
+++ b/widgets/floatingtext/org.eclipse.nebula.widgets.floatingtext.feature/pom.xml
@@ -18,7 +18,7 @@ Contributors:
 	<parent>
 		<groupId>org.eclipse.nebula</groupId>
 		<artifactId>floatingtext</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
+		<version>1.0.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.floatingtext.feature</artifactId>

--- a/widgets/floatingtext/org.eclipse.nebula.widgets.floatingtext.snippets/META-INF/MANIFEST.MF
+++ b/widgets/floatingtext/org.eclipse.nebula.widgets.floatingtext.snippets/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Nebula Floating Text Snippets
 Bundle-SymbolicName: org.eclipse.nebula.widgets.floatingtext.snippets
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.0.1.qualifier
 Bundle-Vendor: Eclipse Nebula
 Automatic-Module-Name: org.eclipse.nebula.widgets.floatingtext.snippets
 Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/widgets/floatingtext/org.eclipse.nebula.widgets.floatingtext.snippets/pom.xml
+++ b/widgets/floatingtext/org.eclipse.nebula.widgets.floatingtext.snippets/pom.xml
@@ -18,7 +18,7 @@ Contributors:
 	<parent>
 		<groupId>org.eclipse.nebula</groupId>
 		<artifactId>floatingtext</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
+		<version>1.0.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.floatingtext.snippets</artifactId>

--- a/widgets/floatingtext/org.eclipse.nebula.widgets.floatingtext/META-INF/MANIFEST.MF
+++ b/widgets/floatingtext/org.eclipse.nebula.widgets.floatingtext/META-INF/MANIFEST.MF
@@ -2,9 +2,9 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Nebula Floating Text Widget
 Bundle-SymbolicName: org.eclipse.nebula.widgets.floatingtext
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.0.1.qualifier
 Bundle-Vendor: Eclipse Nebula
 Automatic-Module-Name: org.eclipse.nebula.widgets.floatingtext
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.swt
-Export-Package: org.eclipse.nebula.widgets.floatingtext;version="1.0.0"
+Export-Package: org.eclipse.nebula.widgets.floatingtext;version="1.0.1"

--- a/widgets/floatingtext/org.eclipse.nebula.widgets.floatingtext/pom.xml
+++ b/widgets/floatingtext/org.eclipse.nebula.widgets.floatingtext/pom.xml
@@ -18,7 +18,7 @@ Contributors:
 	<parent>
 		<groupId>org.eclipse.nebula</groupId>
 		<artifactId>floatingtext</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
+		<version>1.0.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.floatingtext</artifactId>

--- a/widgets/floatingtext/org.eclipse.nebula.widgets.floatingtext/src/org/eclipse/nebula/widgets/floatingtext/FloatingText.java
+++ b/widgets/floatingtext/org.eclipse.nebula.widgets.floatingtext/src/org/eclipse/nebula/widgets/floatingtext/FloatingText.java
@@ -206,9 +206,11 @@ public class FloatingText extends Composite {
 			return;
 		}
 
+		if (fLabelFont != null) {
+			fLabelFont.dispose();
+		}
 		fLabelFont = findFittingFont(fLabel);
 
-		fLabel.getFont().dispose();
 		fLabel.setFont(fLabelFont);
 		fLabel.setText(message);
 	}

--- a/widgets/floatingtext/pom.xml
+++ b/widgets/floatingtext/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 
 	<artifactId>floatingtext</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
+	<version>1.0.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<modules>


### PR DESCRIPTION
The FloatingText widget's doSetLabelText() method could trigger "widget is disposed" exceptions. Multiple calls would create new Font objects without disposing the previous ones, and the code incorrectly disposed system-managed fonts via
fLabel.getFont().dispose().