### PR TITLE
Prepare for the 3.4.0 release cycle

### DIFF
--- a/releng/org.eclipse.nebula.feature/feature.xml
+++ b/releng/org.eclipse.nebula.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.nebula.feature"
       label="Nebula All Mature Widgets SDK"
-      version="3.3.0.qualifier"
+      version="3.4.0.qualifier"
       provider-name="Eclipse Nebula">
 
    <description url="http://eclipse.org/nebula">

--- a/releng/org.eclipse.nebula.feature/pom.xml
+++ b/releng/org.eclipse.nebula.feature/pom.xml
@@ -24,7 +24,7 @@ Contributors:
 	</parent>
 
 	<artifactId>org.eclipse.nebula.feature</artifactId>
-	<version>3.3.0-SNAPSHOT</version>
+	<version>3.4.0-SNAPSHOT</version>
 	<packaging>eclipse-feature</packaging>
 
 	<name>Eclipse Nebula Feature</name>


### PR DESCRIPTION
@wimjongman 

I assume the next release cycle is 3.4.0. 

This change will ensure the generated update site version is updated for the next build:

<img width="497" height="66" alt="image" src="https://github.com/user-attachments/assets/6f16870f-3c7d-4f1b-a8d0-3747df587a07" />
