### PR TITLE
Fixes #686 - [RichText] Add support for monitor specific scaling

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -62,10 +62,10 @@ jobs:
         # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
 
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
         cache: maven
     - name: Set up Maven

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '17' ]
+        java: [ '21' ]
     name: Java ${{ matrix.java }} compile
     steps:
     - uses: actions/checkout@v4

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
 
   tools {
     maven 'apache-maven-latest'
-    jdk 'temurin-jdk17-latest'
+    jdk 'temurin-jdk21-latest'
   }
 
   environment {

--- a/releng/org.eclipse.nebula.nebula-parent/pom.xml
+++ b/releng/org.eclipse.nebula.nebula-parent/pom.xml
@@ -36,8 +36,8 @@ Contributors:
 		<target-platform-gef>https://download.eclipse.org/tools/gef/classic/releases/latest</target-platform-gef>
 		<target-platform-swtbot>https://download.eclipse.org/technology/swtbot/releases/latest</target-platform-swtbot>
 
-		<maven.compiler.source>17</maven.compiler.source>
-		<maven.compiler.target>17</maven.compiler.target>
+		<maven.compiler.source>21</maven.compiler.source>
+		<maven.compiler.target>21</maven.compiler.target>
 
 		<tests.vmargs></tests.vmargs>
 		<sonar.core.codeCoveragePlugin>jacoco</sonar.core.codeCoveragePlugin>
@@ -92,7 +92,7 @@ Contributors:
 				<artifactId>target-platform-configuration</artifactId>
 				<version>${tycho-version}</version>
 				<configuration>
-					<executionEnvironment>JavaSE-17</executionEnvironment>
+					<executionEnvironment>JavaSE-21</executionEnvironment>
 					<pomDependencies>consider</pomDependencies>
 					<environments>
 						<environment>

--- a/releng/org.eclipse.nebula.site/promotion/pom.xml
+++ b/releng/org.eclipse.nebula.site/promotion/pom.xml
@@ -32,7 +32,7 @@ SPDX-License-Identifier: EPL-2.0
 				<artifactId>tycho-eclipserun-plugin</artifactId>
 				<version>${tycho-version}</version>
 				<configuration>
-					<executionEnvironment>JavaSE-17</executionEnvironment>
+					<executionEnvironment>JavaSE-21</executionEnvironment>
 					<dependencies>
 						<dependency>
 							<artifactId>org.eclipse.justj.p2</artifactId>

--- a/widgets/richtext/org.eclipse.nebula.widgets.richtext.example.e4/.classpath
+++ b/widgets/richtext/org.eclipse.nebula.widgets.richtext.example.e4/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/widgets/richtext/org.eclipse.nebula.widgets.richtext.example.e4/.settings/org.eclipse.jdt.core.prefs
+++ b/widgets/richtext/org.eclipse.nebula.widgets.richtext.example.e4/.settings/org.eclipse.jdt.core.prefs
@@ -1,13 +1,13 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
-org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=21
+org.eclipse.jdt.core.compiler.compliance=21
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
-org.eclipse.jdt.core.compiler.source=11
+org.eclipse.jdt.core.compiler.source=21
 org.eclipse.jdt.core.formatter.align_type_members_on_columns=false
 org.eclipse.jdt.core.formatter.alignment_for_additive_operator=16
 org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression=16

--- a/widgets/richtext/org.eclipse.nebula.widgets.richtext.example.e4/META-INF/MANIFEST.MF
+++ b/widgets/richtext/org.eclipse.nebula.widgets.richtext.example.e4/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Nebula E4 Rich Text Example
 Bundle-SymbolicName: org.eclipse.nebula.widgets.richtext.example.e4;singleton:=true
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.7.0.qualifier
 Bundle-Vendor: Eclipse Nebula
 Import-Package: jakarta.annotation;version="[2.1.0,3.0.0)"
 Require-Bundle: org.eclipse.core.runtime,

--- a/widgets/richtext/org.eclipse.nebula.widgets.richtext.example.e4/META-INF/MANIFEST.MF
+++ b/widgets/richtext/org.eclipse.nebula.widgets.richtext.example.e4/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Nebula E4 Rich Text Example
 Bundle-SymbolicName: org.eclipse.nebula.widgets.richtext.example.e4;singleton:=true
 Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Eclipse Nebula
-Import-Package: javax.annotation
+Import-Package: jakarta.annotation;version="[2.1.0,3.0.0)"
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.swt,
  org.eclipse.jface,
@@ -16,5 +16,5 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.e4.core.contexts;bundle-version="1.3.100",
  org.eclipse.nebula.widgets.richtext;bundle-version="1.0.0",
  org.eclipse.nebula.widgets.richtext.example;bundle-version="1.0.0"
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Automatic-Module-Name: org.eclipse.nebula.widgets.richtext.example.e4

--- a/widgets/richtext/org.eclipse.nebula.widgets.richtext.example.e4/org.eclipse.nebula.widgets.richtext.example.e4.product
+++ b/widgets/richtext/org.eclipse.nebula.widgets.richtext.example.e4/org.eclipse.nebula.widgets.richtext.example.e4.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="org.eclipse.nebula.widgets.richtext.example.e4" id="org.eclipse.nebula.widgets.richtext.example.e4.product" application="org.eclipse.e4.ui.workbench.swt.E4Application" version="1.0.0.qualifier" useFeatures="false" includeLaunchers="true">
+<product name="org.eclipse.nebula.widgets.richtext.example.e4" id="org.eclipse.nebula.widgets.richtext.example.e4.product" application="org.eclipse.e4.ui.workbench.swt.E4Application" version="1.7.0.qualifier" type="bundles" includeLaunchers="true" autoIncludeRequirements="true">
 
    <configIni use="default">
    </configIni>
@@ -32,22 +32,22 @@
       <plugin id="org.eclipse.core.databinding.property"/>
       <plugin id="org.eclipse.core.expressions"/>
       <plugin id="org.eclipse.core.filesystem"/>
-      <plugin id="org.eclipse.core.filesystem.aix.ppc" fragment="true"/>
-      <plugin id="org.eclipse.core.filesystem.hpux.ia64_32" fragment="true"/>
-      <plugin id="org.eclipse.core.filesystem.java7" fragment="true"/>
-      <plugin id="org.eclipse.core.filesystem.linux.ppc" fragment="true"/>
-      <plugin id="org.eclipse.core.filesystem.linux.x86" fragment="true"/>
-      <plugin id="org.eclipse.core.filesystem.linux.x86_64" fragment="true"/>
-      <plugin id="org.eclipse.core.filesystem.macosx" fragment="true"/>
-      <plugin id="org.eclipse.core.filesystem.solaris.sparc" fragment="true"/>
-      <plugin id="org.eclipse.core.filesystem.win32.x86" fragment="true"/>
-      <plugin id="org.eclipse.core.filesystem.win32.x86_64" fragment="true"/>
+      <plugin id="org.eclipse.core.filesystem.aix.ppc"/>
+      <plugin id="org.eclipse.core.filesystem.hpux.ia64_32"/>
+      <plugin id="org.eclipse.core.filesystem.java7"/>
+      <plugin id="org.eclipse.core.filesystem.linux.ppc"/>
+      <plugin id="org.eclipse.core.filesystem.linux.x86"/>
+      <plugin id="org.eclipse.core.filesystem.linux.x86_64"/>
+      <plugin id="org.eclipse.core.filesystem.macosx"/>
+      <plugin id="org.eclipse.core.filesystem.solaris.sparc"/>
+      <plugin id="org.eclipse.core.filesystem.win32.x86"/>
+      <plugin id="org.eclipse.core.filesystem.win32.x86_64"/>
       <plugin id="org.eclipse.core.jobs"/>
       <plugin id="org.eclipse.core.resources"/>
-      <plugin id="org.eclipse.core.resources.win32.x86" fragment="true"/>
-      <plugin id="org.eclipse.core.resources.win32.x86_64" fragment="true"/>
+      <plugin id="org.eclipse.core.resources.win32.x86"/>
+      <plugin id="org.eclipse.core.resources.win32.x86_64"/>
       <plugin id="org.eclipse.core.runtime"/>
-      <plugin id="org.eclipse.core.runtime.compatibility.registry" fragment="true"/>
+      <plugin id="org.eclipse.core.runtime.compatibility.registry"/>
       <plugin id="org.eclipse.e4.core.commands"/>
       <plugin id="org.eclipse.e4.core.contexts"/>
       <plugin id="org.eclipse.e4.core.di"/>
@@ -85,27 +85,27 @@
       <plugin id="org.eclipse.nebula.widgets.richtext.example"/>
       <plugin id="org.eclipse.nebula.widgets.richtext.example.e4"/>
       <plugin id="org.eclipse.osgi"/>
-      <plugin id="org.eclipse.osgi.compatibility.state" fragment="true"/>
+      <plugin id="org.eclipse.osgi.compatibility.state"/>
       <plugin id="org.eclipse.osgi.services"/>
       <plugin id="org.eclipse.swt"/>
-      <plugin id="org.eclipse.swt.carbon.macosx" fragment="true"/>
-      <plugin id="org.eclipse.swt.cocoa.macosx" fragment="true"/>
-      <plugin id="org.eclipse.swt.cocoa.macosx.x86_64" fragment="true"/>
-      <plugin id="org.eclipse.swt.gtk.linux.ppc" fragment="true"/>
-      <plugin id="org.eclipse.swt.gtk.linux.ppc64" fragment="true"/>
-      <plugin id="org.eclipse.swt.gtk.linux.s390" fragment="true"/>
-      <plugin id="org.eclipse.swt.gtk.linux.s390x" fragment="true"/>
-      <plugin id="org.eclipse.swt.gtk.linux.x86" fragment="true"/>
-      <plugin id="org.eclipse.swt.gtk.linux.x86_64" fragment="true"/>
-      <plugin id="org.eclipse.swt.gtk.solaris.sparc" fragment="true"/>
-      <plugin id="org.eclipse.swt.gtk.solaris.x86" fragment="true"/>
-      <plugin id="org.eclipse.swt.motif.aix.ppc" fragment="true"/>
-      <plugin id="org.eclipse.swt.motif.hpux.ia64_32" fragment="true"/>
-      <plugin id="org.eclipse.swt.motif.linux.x86" fragment="true"/>
-      <plugin id="org.eclipse.swt.motif.solaris.sparc" fragment="true"/>
-      <plugin id="org.eclipse.swt.photon.qnx.x86" fragment="true"/>
-      <plugin id="org.eclipse.swt.win32.win32.x86" fragment="true"/>
-      <plugin id="org.eclipse.swt.win32.win32.x86_64" fragment="true"/>
+      <plugin id="org.eclipse.swt.carbon.macosx"/>
+      <plugin id="org.eclipse.swt.cocoa.macosx"/>
+      <plugin id="org.eclipse.swt.cocoa.macosx.x86_64"/>
+      <plugin id="org.eclipse.swt.gtk.linux.ppc"/>
+      <plugin id="org.eclipse.swt.gtk.linux.ppc64"/>
+      <plugin id="org.eclipse.swt.gtk.linux.s390"/>
+      <plugin id="org.eclipse.swt.gtk.linux.s390x"/>
+      <plugin id="org.eclipse.swt.gtk.linux.x86"/>
+      <plugin id="org.eclipse.swt.gtk.linux.x86_64"/>
+      <plugin id="org.eclipse.swt.gtk.solaris.sparc"/>
+      <plugin id="org.eclipse.swt.gtk.solaris.x86"/>
+      <plugin id="org.eclipse.swt.motif.aix.ppc"/>
+      <plugin id="org.eclipse.swt.motif.hpux.ia64_32"/>
+      <plugin id="org.eclipse.swt.motif.linux.x86"/>
+      <plugin id="org.eclipse.swt.motif.solaris.sparc"/>
+      <plugin id="org.eclipse.swt.photon.qnx.x86"/>
+      <plugin id="org.eclipse.swt.win32.win32.x86"/>
+      <plugin id="org.eclipse.swt.win32.win32.x86_64"/>
       <plugin id="org.w3c.css.sac"/>
       <plugin id="org.w3c.dom.events"/>
       <plugin id="org.w3c.dom.smil"/>

--- a/widgets/richtext/org.eclipse.nebula.widgets.richtext.example.e4/pom.xml
+++ b/widgets/richtext/org.eclipse.nebula.widgets.richtext.example.e4/pom.xml
@@ -23,7 +23,7 @@ Contributors:
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.richtext.example.e4</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
+	<version>1.7.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/widgets/richtext/org.eclipse.nebula.widgets.richtext.example.e4/src/org/eclipse/nebula/widgets/richtext/example/e4/part/JFaceViewerIntegrationExamplePart.java
+++ b/widgets/richtext/org.eclipse.nebula.widgets.richtext.example.e4/src/org/eclipse/nebula/widgets/richtext/example/e4/part/JFaceViewerIntegrationExamplePart.java
@@ -15,7 +15,7 @@
  *****************************************************************************/
 package org.eclipse.nebula.widgets.richtext.example.e4.part;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 
 import org.eclipse.nebula.widgets.richtext.example.JFaceViewerIntegrationExample;
 import org.eclipse.swt.widgets.Composite;

--- a/widgets/richtext/org.eclipse.nebula.widgets.richtext.example.e4/src/org/eclipse/nebula/widgets/richtext/example/e4/part/RichTextEditorExamplePart.java
+++ b/widgets/richtext/org.eclipse.nebula.widgets.richtext.example.e4/src/org/eclipse/nebula/widgets/richtext/example/e4/part/RichTextEditorExamplePart.java
@@ -15,7 +15,7 @@
  *****************************************************************************/
 package org.eclipse.nebula.widgets.richtext.example.e4.part;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 
 import org.eclipse.nebula.widgets.richtext.example.RichTextEditorExample;
 import org.eclipse.swt.widgets.Composite;

--- a/widgets/richtext/org.eclipse.nebula.widgets.richtext.example.e4/src/org/eclipse/nebula/widgets/richtext/example/e4/part/RichTextViewerExamplePart.java
+++ b/widgets/richtext/org.eclipse.nebula.widgets.richtext.example.e4/src/org/eclipse/nebula/widgets/richtext/example/e4/part/RichTextViewerExamplePart.java
@@ -15,7 +15,7 @@
  *****************************************************************************/
 package org.eclipse.nebula.widgets.richtext.example.e4.part;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 
 import org.eclipse.nebula.widgets.richtext.example.RichTextViewerExample;
 import org.eclipse.swt.widgets.Composite;

--- a/widgets/richtext/org.eclipse.nebula.widgets.richtext.example/.classpath
+++ b/widgets/richtext/org.eclipse.nebula.widgets.richtext.example/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/widgets/richtext/org.eclipse.nebula.widgets.richtext.example/.settings/org.eclipse.jdt.core.prefs
+++ b/widgets/richtext/org.eclipse.nebula.widgets.richtext.example/.settings/org.eclipse.jdt.core.prefs
@@ -1,13 +1,13 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
-org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=21
+org.eclipse.jdt.core.compiler.compliance=21
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
-org.eclipse.jdt.core.compiler.source=11
+org.eclipse.jdt.core.compiler.source=21
 org.eclipse.jdt.core.formatter.align_type_members_on_columns=false
 org.eclipse.jdt.core.formatter.alignment_for_additive_operator=16
 org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression=16

--- a/widgets/richtext/org.eclipse.nebula.widgets.richtext.example/META-INF/MANIFEST.MF
+++ b/widgets/richtext/org.eclipse.nebula.widgets.richtext.example/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Nebula Rich Text Editor Examples
 Bundle-SymbolicName: org.eclipse.nebula.widgets.richtext.example
 Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Eclipse Nebula
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.eclipse.jface;bundle-version="3.10.1",
  org.eclipse.nebula.widgets.richtext;bundle-version="1.0.0"
 Export-Package: org.eclipse.nebula.widgets.richtext.example

--- a/widgets/richtext/org.eclipse.nebula.widgets.richtext.example/META-INF/MANIFEST.MF
+++ b/widgets/richtext/org.eclipse.nebula.widgets.richtext.example/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Nebula Rich Text Editor Examples
 Bundle-SymbolicName: org.eclipse.nebula.widgets.richtext.example
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.7.0.qualifier
 Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.eclipse.jface;bundle-version="3.10.1",

--- a/widgets/richtext/org.eclipse.nebula.widgets.richtext.example/pom.xml
+++ b/widgets/richtext/org.eclipse.nebula.widgets.richtext.example/pom.xml
@@ -23,7 +23,7 @@ Contributors:
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.richtext.example</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
+	<version>1.7.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/widgets/richtext/org.eclipse.nebula.widgets.richtext.example/src/org/eclipse/nebula/widgets/richtext/example/JFaceViewerIntegrationExample.java
+++ b/widgets/richtext/org.eclipse.nebula.widgets.richtext.example/src/org/eclipse/nebula/widgets/richtext/example/JFaceViewerIntegrationExample.java
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2015, 2020 CEA LIST.
+ * Copyright (c) 2015, 2026 CEA LIST.
  *
  *
  * This program and the accompanying materials
@@ -38,7 +38,6 @@ import org.eclipse.jface.viewers.ViewerCell;
 import org.eclipse.nebula.widgets.richtext.RichTextCellEditor;
 import org.eclipse.nebula.widgets.richtext.RichTextCellLabelProvider;
 import org.eclipse.nebula.widgets.richtext.RichTextEditorConfiguration;
-import org.eclipse.nebula.widgets.richtext.ScalingHelper;
 import org.eclipse.nebula.widgets.richtext.toolbar.ToolbarButton;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Image;
@@ -55,9 +54,7 @@ public class JFaceViewerIntegrationExample {
 
 		final Shell shell = new Shell(display);
 		shell.setText("Rich Text Editor JFace viewer integration example");
-		shell.setSize(
-				ScalingHelper.convertHorizontalPixelToDpi(800), 
-				ScalingHelper.convertVerticalPixelToDpi(600));
+		shell.setSize(800,  600);
 
 		shell.setLayout(new GridLayout(1, true));
 
@@ -281,8 +278,8 @@ public class JFaceViewerIntegrationExample {
 			LocalResourceManager resourceMgr = new LocalResourceManager(JFaceResources.getResources());
 			URL checked = JFaceViewerIntegrationExample.class.getResource("images/checked.gif");
 			URL unchecked = JFaceViewerIntegrationExample.class.getResource("images/unchecked.gif");
-			this.checkedImg = resourceMgr.createImage(ImageDescriptor.createFromURL(checked));
-			this.uncheckedImg = resourceMgr.createImage(ImageDescriptor.createFromURL(unchecked));
+			this.checkedImg = resourceMgr.create(ImageDescriptor.createFromURL(checked));
+			this.uncheckedImg = resourceMgr.create(ImageDescriptor.createFromURL(unchecked));
 		}
 
 		@Override

--- a/widgets/richtext/org.eclipse.nebula.widgets.richtext.example/src/org/eclipse/nebula/widgets/richtext/example/RichTextEditorExample.java
+++ b/widgets/richtext/org.eclipse.nebula.widgets.richtext.example/src/org/eclipse/nebula/widgets/richtext/example/RichTextEditorExample.java
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2015, 2025 CEA LIST.
+ * Copyright (c) 2015, 2026 CEA LIST.
  *
  *
  * This program and the accompanying materials
@@ -20,7 +20,6 @@ import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.nebula.widgets.richtext.RichTextEditor;
 import org.eclipse.nebula.widgets.richtext.RichTextEditorConfiguration;
-import org.eclipse.nebula.widgets.richtext.ScalingHelper;
 import org.eclipse.nebula.widgets.richtext.toolbar.ToolbarButton;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.KeyAdapter;
@@ -47,9 +46,7 @@ public class RichTextEditorExample {
 
 		final Shell shell = new Shell(display);
 		shell.setText("SWT Rich Text Editor example");
-		shell.setSize(
-				ScalingHelper.convertHorizontalPixelToDpi(800), 
-				ScalingHelper.convertVerticalPixelToDpi(600));
+		shell.setSize(800, 600);
 
 		shell.setLayout(new GridLayout(1, true));
 

--- a/widgets/richtext/org.eclipse.nebula.widgets.richtext.example/src/org/eclipse/nebula/widgets/richtext/example/RichTextViewerExample.java
+++ b/widgets/richtext/org.eclipse.nebula.widgets.richtext.example/src/org/eclipse/nebula/widgets/richtext/example/RichTextViewerExample.java
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2015, 2020 CEA LIST.
+ * Copyright (c) 2015, 2026 CEA LIST.
  *
  *
  * This program and the accompanying materials
@@ -17,7 +17,6 @@ package org.eclipse.nebula.widgets.richtext.example;
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.nebula.widgets.richtext.RichTextEditor;
 import org.eclipse.nebula.widgets.richtext.RichTextViewer;
-import org.eclipse.nebula.widgets.richtext.ScalingHelper;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
@@ -36,9 +35,7 @@ public class RichTextViewerExample {
 
 		final Shell shell = new Shell(display);
 		shell.setText("SWT Rich Text Editor example");
-		shell.setSize(
-				ScalingHelper.convertHorizontalPixelToDpi(800), 
-				ScalingHelper.convertVerticalPixelToDpi(600));
+		shell.setSize(800, 600);
 
 		shell.setLayout(new GridLayout(1, true));
 

--- a/widgets/richtext/org.eclipse.nebula.widgets.richtext.feature/feature.xml
+++ b/widgets/richtext/org.eclipse.nebula.widgets.richtext.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.nebula.widgets.richtext.feature"
       label="Nebula RichText"
-      version="1.6.0.qualifier"
+      version="1.7.0.qualifier"
       provider-name="Eclipse Nebula">
 
    <description url="http://eclipse.org/nebula">

--- a/widgets/richtext/org.eclipse.nebula.widgets.richtext.feature/pom.xml
+++ b/widgets/richtext/org.eclipse.nebula.widgets.richtext.feature/pom.xml
@@ -32,7 +32,7 @@ Contributors:
 
 	<artifactId>org.eclipse.nebula.widgets.richtext.feature</artifactId>
 	<packaging>eclipse-feature</packaging>
-	<version>1.6.0-SNAPSHOT</version>
+	<version>1.7.0-SNAPSHOT</version>
 
 	<name>Nebula RichText Widget</name>
 

--- a/widgets/richtext/org.eclipse.nebula.widgets.richtext/.classpath
+++ b/widgets/richtext/org.eclipse.nebula.widgets.richtext/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/widgets/richtext/org.eclipse.nebula.widgets.richtext/.settings/org.eclipse.jdt.core.prefs
+++ b/widgets/richtext/org.eclipse.nebula.widgets.richtext/.settings/org.eclipse.jdt.core.prefs
@@ -1,13 +1,13 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
-org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=21
+org.eclipse.jdt.core.compiler.compliance=21
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
-org.eclipse.jdt.core.compiler.source=11
+org.eclipse.jdt.core.compiler.source=21
 org.eclipse.jdt.core.formatter.align_type_members_on_columns=false
 org.eclipse.jdt.core.formatter.alignment_for_additive_operator=16
 org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression=16

--- a/widgets/richtext/org.eclipse.nebula.widgets.richtext/META-INF/MANIFEST.MF
+++ b/widgets/richtext/org.eclipse.nebula.widgets.richtext/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Nebula Rich Text Widget
 Bundle-SymbolicName: org.eclipse.nebula.widgets.richtext
 Bundle-Version: 1.6.0.qualifier
 Bundle-Vendor: Eclipse Nebula
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.eclipse.core.runtime
 Eclipse-BundleShape: dir
 Export-Package: org.eclipse.nebula.widgets.richtext;version="1.5.0",

--- a/widgets/richtext/org.eclipse.nebula.widgets.richtext/META-INF/MANIFEST.MF
+++ b/widgets/richtext/org.eclipse.nebula.widgets.richtext/META-INF/MANIFEST.MF
@@ -2,12 +2,12 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Nebula Rich Text Widget
 Bundle-SymbolicName: org.eclipse.nebula.widgets.richtext
-Bundle-Version: 1.6.0.qualifier
+Bundle-Version: 1.7.0.qualifier
 Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.eclipse.core.runtime
 Eclipse-BundleShape: dir
-Export-Package: org.eclipse.nebula.widgets.richtext;version="1.5.0",
+Export-Package: org.eclipse.nebula.widgets.richtext;version="1.7.0",
  org.eclipse.nebula.widgets.richtext.painter;version="1.2.0",
  org.eclipse.nebula.widgets.richtext.painter.instructions;version="1.3.0",
  org.eclipse.nebula.widgets.richtext.toolbar;version="1.2.0"

--- a/widgets/richtext/org.eclipse.nebula.widgets.richtext/pom.xml
+++ b/widgets/richtext/org.eclipse.nebula.widgets.richtext/pom.xml
@@ -24,6 +24,6 @@ Contributors:
 
 	<artifactId>org.eclipse.nebula.widgets.richtext</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>1.6.0-SNAPSHOT</version>
+	<version>1.7.0-SNAPSHOT</version>
 
 </project>

--- a/widgets/richtext/org.eclipse.nebula.widgets.richtext/src/org/eclipse/nebula/widgets/richtext/RichTextCellEditor.java
+++ b/widgets/richtext/org.eclipse.nebula.widgets.richtext/src/org/eclipse/nebula/widgets/richtext/RichTextCellEditor.java
@@ -142,9 +142,9 @@ public class RichTextCellEditor extends CellEditor {
 	public RichTextCellEditor(Composite parent, RichTextEditorConfiguration editorConfiguration, int style) {
 		super(parent, style | SWT.EMBEDDED);
 		
-		this.parent = parent;
-		
 		this.editorConfiguration = editorConfiguration;
+		
+		this.parent = parent;
 
 		// call super#create(Composite) now because we override it locally empty
 		// to be able to set member variables like the ToolbarConfiguration.
@@ -223,9 +223,29 @@ public class RichTextCellEditor extends CellEditor {
 	 * @return The minimum dimension used for the rich text editor control.
 	 */
 	protected Point getMinimumDimension() {
-		return new Point(
-				ScalingHelper.getZoomedValue(370, this.parent.getShell().getZoom()),
-				ScalingHelper.getZoomedValue(200, this.parent.getShell().getZoom()));
+		String autoScaleProperty = ScalingHelper.getAutoScaleProperty(this.parent.getDisplay());
+		
+		if ("false".equals(autoScaleProperty) || "integer".equals(autoScaleProperty)) {
+			// the browser returns the dimensions according to the display scaling and is not aware of the SWT auto scaling
+			// in case SWT auto scaling is disabled or set to integer, we need to manually increase the minimum dimensions
+			// according to the display scaling to ensure the shell is large enough for the browser content
+			return new Point(
+					ScalingHelper.getZoomedValue(370,  parent.getShell().getZoom()), 
+					ScalingHelper.getZoomedValue(230,  parent.getShell().getZoom()));
+		} else {
+			try {
+				int zoomLevel = Integer.parseInt(autoScaleProperty);
+				if (zoomLevel < parent.getShell().getZoom()) {
+					return new Point(
+							ScalingHelper.getZoomedValue(370,  parent.getShell().getZoom()), 
+							ScalingHelper.getZoomedValue(230,  parent.getShell().getZoom()));
+				}
+			} catch (NumberFormatException e) {
+				// in case of an invalid value, do nothing
+			}
+			
+		}
+		return new Point(370, 230);
 	}
 
 	@Override

--- a/widgets/richtext/org.eclipse.nebula.widgets.richtext/src/org/eclipse/nebula/widgets/richtext/RichTextCellEditor.java
+++ b/widgets/richtext/org.eclipse.nebula.widgets.richtext/src/org/eclipse/nebula/widgets/richtext/RichTextCellEditor.java
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2015, 2020 CEA LIST.
+ * Copyright (c) 2015, 2026 CEA LIST.
  *
  *
  * This program and the accompanying materials
@@ -66,6 +66,8 @@ public class RichTextCellEditor extends CellEditor {
 	protected RichTextEditorConfiguration editorConfiguration;
 
 	private ModifyListener modifyListener;
+	
+	private Composite parent;
 
 	/**
 	 * Create a resizable {@link RichTextCellEditor} with the default {@link RichTextEditorConfiguration}.
@@ -139,6 +141,9 @@ public class RichTextCellEditor extends CellEditor {
 	 */
 	public RichTextCellEditor(Composite parent, RichTextEditorConfiguration editorConfiguration, int style) {
 		super(parent, style | SWT.EMBEDDED);
+		
+		this.parent = parent;
+		
 		this.editorConfiguration = editorConfiguration;
 
 		// call super#create(Composite) now because we override it locally empty
@@ -219,8 +224,8 @@ public class RichTextCellEditor extends CellEditor {
 	 */
 	protected Point getMinimumDimension() {
 		return new Point(
-				ScalingHelper.convertHorizontalPixelToDpi(370),
-				ScalingHelper.convertVerticalPixelToDpi(200));
+				ScalingHelper.getZoomedValue(370, this.parent.getShell().getZoom()),
+				ScalingHelper.getZoomedValue(200, this.parent.getShell().getZoom()));
 	}
 
 	@Override

--- a/widgets/richtext/org.eclipse.nebula.widgets.richtext/src/org/eclipse/nebula/widgets/richtext/RichTextPainter.java
+++ b/widgets/richtext/org.eclipse.nebula.widgets.richtext/src/org/eclipse/nebula/widgets/richtext/RichTextPainter.java
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2015, 2023 CEA LIST.
+ * Copyright (c) 2015, 2026 CEA LIST.
  *
  *
  * This program and the accompanying materials
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.Map;
+import java.util.function.Supplier;
 
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLInputFactory;
@@ -123,6 +124,8 @@ public class RichTextPainter {
 	private EntityReplacer entityReplacer = new DefaultEntityReplacer();
 
 	private String wordSplitRegex = "\\s";
+	
+	private Supplier<Integer> zoomSupplier;
 
 	/**
 	 * Create a new {@link RichTextPainter} with disabled word wrapping.
@@ -139,9 +142,25 @@ public class RichTextPainter {
 	 *            if not.
 	 */
 	public RichTextPainter(boolean wordWrap) {
-		this.wordWrap = wordWrap;
+		this(wordWrap, () -> 100);
 	}
 
+
+	/**
+	 * Create a new {@link RichTextPainter}.
+	 *
+	 * @param wordWrap
+	 *            <code>true</code> if automatic word wrapping should be enabled, <code>false</code>
+	 *            if not.
+	 * @param zoomSupplier
+	 *            A supplier for the current zoom level in percent, e.g. 100 for 100%. This is used
+	 *            to calculate the font size in case of zooming.
+	 */
+	public RichTextPainter(boolean wordWrap, Supplier<Integer> zoomSupplier) {
+		this.wordWrap = wordWrap;
+		this.zoomSupplier = zoomSupplier;
+	}
+	
 	/**
 	 * Processes the HTML input to calculate the preferred size. Does not perform rendering.
 	 *
@@ -628,7 +647,7 @@ public class RichTextPainter {
 							int pixel = Integer.valueOf(pixelValue.trim());
 							// the size in pixels specified in HTML
 							// so we need to convert it to point
-							int pointSize = 72 * ScalingHelper.convertHorizontalPixelToDpi(pixel) / Display.getDefault().getDPI().x;
+							int pointSize = Math.round((pixel * (this.zoomSupplier.get() / 100f)) * (72f / Display.getDefault().getDPI().x));
 							styleInstruction.setFontSize(pointSize);
 						} catch (NumberFormatException e) {
 							e.printStackTrace();
@@ -711,9 +730,9 @@ public class RichTextPainter {
 	 *         <b>Note:</b> Between two paragraphs the paragraphSpace * 2 is added as space.
 	 */
 	public int getParagraphSpace() {
-		return ScalingHelper.convertVerticalPixelToDpi(this.paragraphSpace);
+		return ScalingHelper.getZoomedValue(this.paragraphSpace, this.zoomSupplier.get());
 	}
-
+	
 	/**
 	 * @param paragraphSpace
 	 *            The space that should be applied before and after a paragraph.<br>

--- a/widgets/richtext/org.eclipse.nebula.widgets.richtext/src/org/eclipse/nebula/widgets/richtext/RichTextPainter.java
+++ b/widgets/richtext/org.eclipse.nebula.widgets.richtext/src/org/eclipse/nebula/widgets/richtext/RichTextPainter.java
@@ -647,7 +647,8 @@ public class RichTextPainter {
 							int pixel = Integer.valueOf(pixelValue.trim());
 							// the size in pixels specified in HTML
 							// so we need to convert it to point
-							int pointSize = Math.round((pixel * (this.zoomSupplier.get() / 100f)) * (72f / Display.getDefault().getDPI().x));
+							int dpi = Display.getCurrent() != null ? Display.getCurrent().getDPI().x : Display.getDefault().getDPI().x;
+							int pointSize = 72 * pixel / dpi;
 							styleInstruction.setFontSize(pointSize);
 						} catch (NumberFormatException e) {
 							e.printStackTrace();

--- a/widgets/richtext/org.eclipse.nebula.widgets.richtext/src/org/eclipse/nebula/widgets/richtext/RichTextViewer.java
+++ b/widgets/richtext/org.eclipse.nebula.widgets.richtext/src/org/eclipse/nebula/widgets/richtext/RichTextViewer.java
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2015 CEA LIST.
+ * Copyright (c) 2015, 2026 CEA LIST.
  *
  *
  * This program and the accompanying materials
@@ -45,7 +45,7 @@ public class RichTextViewer extends Canvas {
 		super(parent, style | SWT.DOUBLE_BUFFERED);
 
 		final boolean wordWrap = (getStyle() & SWT.WRAP) != 0;
-		this.painter = new RichTextPainter(wordWrap);
+		this.painter = new RichTextPainter(wordWrap, () -> parent.getShell().getZoom());
 
 		addPaintListener(new PaintListener() {
 

--- a/widgets/richtext/org.eclipse.nebula.widgets.richtext/src/org/eclipse/nebula/widgets/richtext/ScalingHelper.java
+++ b/widgets/richtext/org.eclipse.nebula.widgets.richtext/src/org/eclipse/nebula/widgets/richtext/ScalingHelper.java
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2020 Dirk Fauth and others.
+ * Copyright (c) 2020, 2026 Dirk Fauth and others.
  *
  *
  * This program and the accompanying materials
@@ -33,7 +33,9 @@ public final class ScalingHelper {
      * @param dpi
      *            The DPI for which the factor is requested.
      * @return The factor for dpi scaling calculations.
+     * @deprecated The factor can be retrieved via the zoom level of the shell.
      */
+	@Deprecated
     public static float getDpiFactor(int dpi) {
         return Math.max(0.1f, Math.round((dpi / 96f) * 100) / 100f);
     }
@@ -45,7 +47,9 @@ public final class ScalingHelper {
      * @param pixel
      *            the amount of pixels to convert.
      * @return The converted pixels.
+     * @deprecated Use {@link #getZoomedValue(int, int)} instead and pass the zoom level of the shell as second parameter.
      */
+    @Deprecated
     public static int convertHorizontalPixelToDpi(int pixel) {
         return Math.round(pixel * getDpiFactor(Display.getDefault().getDPI().x));
     }
@@ -57,7 +61,9 @@ public final class ScalingHelper {
      * @param dpi
      *            the DPI value to convert.
      * @return The pixel value related to the given DPI
+     * @deprecated Use {@link #getUnzoomedValue(int, int)} instead and pass the zoom level of the shell as second parameter.
      */
+    @Deprecated
     public static int convertHorizontalDpiToPixel(int dpi) {
         return Math.round(dpi / getDpiFactor(Display.getDefault().getDPI().x));
     }
@@ -69,7 +75,9 @@ public final class ScalingHelper {
      * @param pixel
      *            the amount of pixels to convert.
      * @return The converted pixels.
+     * @deprecated Use {@link #getZoomedValue(int, int)} instead and pass the zoom level of the shell as second parameter.
      */
+    @Deprecated
     public static int convertVerticalPixelToDpi(int pixel) {
         return Math.round(pixel * getDpiFactor(Display.getDefault().getDPI().y));
     }
@@ -81,9 +89,30 @@ public final class ScalingHelper {
      * @param dpi
      *            the DPI value to convert.
      * @return The pixel value related to the given DPI
+     * @deprecated Use {@link #getUnzoomedValue(int, int)} instead and pass the zoom level of the shell as second parameter.
      */
+    @Deprecated
     public static int convertVerticalDpiToPixel(int dpi) {
         return Math.round(dpi / getDpiFactor(Display.getDefault().getDPI().y));
     }
 
+    /**
+     * Converts the given amount of pixels to a scaled value using the zoom level of the shell.
+     * @param pixel the amount of pixels to convert.
+     * @param zoom the zoom level of the shell to use for the conversion.
+     * @return The scaled pixel value.
+     */
+    public static int getZoomedValue(int pixel, int zoom) {
+		return Math.round(pixel * (zoom / 100f));
+	}
+    
+    /**
+     * Converts the given scaled value to a pixel value using the zoom level of the shell.
+     * @param pixel the scaled amount of pixels to convert.
+     * @param zoom the zoom level of the shell to use for the conversion.
+     * @return The unscaled pixel value.
+     */
+    public static int getUnzoomedValue(int pixel, int zoom) {
+    	return Math.round(pixel / (zoom / 100f));
+    }
 }

--- a/widgets/richtext/org.eclipse.nebula.widgets.richtext/src/org/eclipse/nebula/widgets/richtext/ScalingHelper.java
+++ b/widgets/richtext/org.eclipse.nebula.widgets.richtext/src/org/eclipse/nebula/widgets/richtext/ScalingHelper.java
@@ -115,4 +115,21 @@ public final class ScalingHelper {
     public static int getUnzoomedValue(int pixel, int zoom) {
     	return Math.round(pixel / (zoom / 100f));
     }
+    
+    /**
+	 * Returns the value of the "swt.autoScale" property. If the property is not set, it returns
+	 * "quarter" if the display is rescaling at runtime, otherwise it returns "integer".
+	 * 
+	 * @param display
+	 *            The Display to check for rescaling at runtime.
+	 * @return The value of the "swt.autoScale" property or the default value based on the display's
+	 *         rescaling behavior.
+	 */
+    public static String getAutoScaleProperty(Display display) {
+		String autoScaleProperty = System.getProperty("swt.autoScale");
+		if (autoScaleProperty == null) {
+			autoScaleProperty = display.isRescalingAtRuntime() ? "quarter" : "integer";
+		}
+		return autoScaleProperty;
+    }
 }

--- a/widgets/richtext/org.eclipse.nebula.widgets.richtext/src/org/eclipse/nebula/widgets/richtext/resources/template.html
+++ b/widgets/richtext/org.eclipse.nebula.widgets.richtext/src/org/eclipse/nebula/widgets/richtext/resources/template.html
@@ -20,9 +20,9 @@
         
         <style type="text/css"> 
         	body { 
-        		margin: 0; 
-        		padding: 0; 
-                overflow: hidden;
+        	    margin: 0; 
+        	    padding: 0;
+            overflow: hidden;
         	}
         	
         	#moveAnchor {

--- a/widgets/richtext/org.eclipse.nebula.widgets.richtext/src/org/eclipse/nebula/widgets/richtext/resources/template.html
+++ b/widgets/richtext/org.eclipse.nebula.widgets.richtext/src/org/eclipse/nebula/widgets/richtext/resources/template.html
@@ -1,6 +1,6 @@
 <!-- 
 /*****************************************************************************
- * Copyright (c) 2015 CEA LIST.
+ * Copyright (c) 2015, 2026 CEA LIST.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -22,6 +22,7 @@
         	body { 
         		margin: 0; 
         		padding: 0; 
+                overflow: hidden;
         	}
         	
         	#moveAnchor {
@@ -159,6 +160,11 @@
         				'instanceReady' 	: function(event) { 
             				//maximize the editor after the editor instance is ready
         					maximizeEditorHeight(); 
+                            
+                            //store the initial dimensions
+                            var height = CKEDITOR.instances.editor.container.$.clientHeight;
+                            var width = CKEDITOR.instances.editor.container.$.clientWidth;
+                            initialDimensions(width, height);
         					
         					event.editor.on('resize', function(resizeEvent) { 
 								if ((prevHeight == null) || prevHeight != resizeEvent.editor.container.$.clientHeight) {
@@ -169,8 +175,7 @@
 										// e.g. toolbar expand/collapse
 										maximizeEditorHeight();
 									}
-									
-									if (resizeCallbackEnabled) {
+									else if (resizeCallbackEnabled) {
 										resizeParentContainer();
 									}
 								}


### PR DESCRIPTION
This PR adds support for monitor specific scaling in the richtext widget.

It uses the new `Shell#getZoom()` API from the upcoming 2026-03 release, so it should not be merged until the release is done.

There is also one open topic related to conversion from a pixel value to point for the font creation.