### PR TITLE
fix: restore original clipping after cell painting in Grid

### DIFF
--- a/widgets/grid/org.eclipse.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/Grid.java
+++ b/widgets/grid/org.eclipse.nebula.widgets.grid/src/org/eclipse/nebula/widgets/grid/Grid.java
@@ -5477,7 +5477,7 @@ public class Grid extends Canvas {
 
 							column.getCellRenderer().paint(gc, item);
 
-							gc.setClipping((Rectangle) null);
+							gc.setClipping(originalClipping);
 
 							// collect the insertMark position
 							if (!insertMark.posFound && insertMarkItem == item


### PR DESCRIPTION
Currently the clipping is set to null and APi states

> Specifying null for the rectangle reverts the receiver's clipping area
to its original value.

This is rather vague but in case of a shell dialog seem to cover the whole size of the control, but in some layout scenarios a control might be clipped, the most common case is a JFace DIalog that is to small to show the full area. In such case currently the row headers (and some lines of the table) are painted outside over other controls (e.g. the button bar.

This now not set the clipping to null, but set the original value passed in and used at other places actually as well already in this method.