### PR TITLE
Remove deprecated Color(Device, ...) constructor usage

### DIFF
--- a/examples/org.eclipse.nebula.examples.feature/feature.xml
+++ b/examples/org.eclipse.nebula.examples.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.nebula.examples.feature"
       label="Nebula Examples View"
-      version="1.0.4.qualifier"
+      version="1.1.0.qualifier"
       provider-name="Eclipse Nebula">
 
    <description url="%featureDescriptionURL">

--- a/examples/org.eclipse.nebula.examples.feature/pom.xml
+++ b/examples/org.eclipse.nebula.examples.feature/pom.xml
@@ -25,7 +25,7 @@ Contributors:
 
 	<artifactId>org.eclipse.nebula.examples.feature</artifactId>
 	<packaging>eclipse-feature</packaging>
-	<version>1.0.4-SNAPSHOT</version>
+	<version>1.1.0-SNAPSHOT</version>
 
 	<name>Nebula Examples View Feature</name>
 

--- a/examples/org.eclipse.nebula.examples/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.nebula.examples/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.nebula.examples;singleton:=true
 Automatic-Module-Name:  org.eclipse.nebula.examples
-Bundle-Version: 1.0.4.qualifier
+Bundle-Version: 1.1.0.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/examples/org.eclipse.nebula.examples/META-INF/MANIFEST.MF
+++ b/examples/org.eclipse.nebula.examples/META-INF/MANIFEST.MF
@@ -6,7 +6,8 @@ Automatic-Module-Name:  org.eclipse.nebula.examples
 Bundle-Version: 1.0.4.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui,
- org.eclipse.core.runtime
+ org.eclipse.core.runtime,
+ org.eclipse.swt;bundle-version="[3.115.0,4.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.eclipse.nebula.examples
 Bundle-Activator: org.eclipse.nebula.examples.internal.Activator

--- a/examples/org.eclipse.nebula.examples/pom.xml
+++ b/examples/org.eclipse.nebula.examples/pom.xml
@@ -24,7 +24,7 @@ Contributors:
 	</parent>
 
 	<artifactId>org.eclipse.nebula.examples</artifactId>
-	<version>1.0.4-SNAPSHOT</version>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/examples/org.eclipse.nebula.examples/src/org/eclipse/nebula/examples/AbstractExampleTab.java
+++ b/examples/org.eclipse.nebula.examples/src/org/eclipse/nebula/examples/AbstractExampleTab.java
@@ -252,7 +252,7 @@ public abstract class AbstractExampleTab {
 			ColorDialog cd = new ColorDialog(Display.getCurrent().getActiveShell());
 			RGB newRGB = cd.open();
 			if (newRGB != null) {
-				Color newColor = new Color(Display.getCurrent(), newRGB);
+				Color newColor = new Color(newRGB);
 				controlExample.setBackground(newColor);
 				if (modifiedBack != null) {
 					modifiedBack.dispose();
@@ -266,7 +266,7 @@ public abstract class AbstractExampleTab {
 			ColorDialog cd = new ColorDialog(Display.getCurrent().getActiveShell());
 			RGB newRGB = cd.open();
 			if (newRGB != null) {
-				Color newColor = new Color(Display.getCurrent(), newRGB);
+				Color newColor = new Color(newRGB);
 				controlExample.setForeground(newColor);
 				if (modifiedFore != null) {
 					modifiedFore.dispose();

--- a/org.eclipse.nebula.presentations.shelf/META-INF/MANIFEST.MF
+++ b/org.eclipse.nebula.presentations.shelf/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Nebula PShelf-based Presentation
 Bundle-SymbolicName: org.eclipse.swt.nebula.presentations.shelf;singleton:=true
-Bundle-Version: 3.3.0.alpha
+Bundle-Version: 3.4.0.alpha
 Bundle-Vendor: Eclipse Nebula
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/org.eclipse.nebula.presentations.shelf/META-INF/MANIFEST.MF
+++ b/org.eclipse.nebula.presentations.shelf/META-INF/MANIFEST.MF
@@ -5,7 +5,8 @@ Bundle-SymbolicName: org.eclipse.swt.nebula.presentations.shelf;singleton:=true
 Bundle-Version: 3.3.0.alpha
 Bundle-Vendor: Eclipse Nebula
 Require-Bundle: org.eclipse.ui,
- org.eclipse.core.runtime
+ org.eclipse.core.runtime,
+ org.eclipse.swt;bundle-version="[3.115.0,4.0.0)"
 Bundle-ClassPath: .,
  nebula_pshelf_ALPHA.jar,
  nebula_pgroup_ALPHA.jar

--- a/org.eclipse.nebula.presentations.shelf/src/org/eclipse/swt/nebula/presentations/shelf/ExpandBarStandaloneStackPresentation.java
+++ b/org.eclipse.nebula.presentations.shelf/src/org/eclipse/swt/nebula/presentations/shelf/ExpandBarStandaloneStackPresentation.java
@@ -74,7 +74,7 @@ public class ExpandBarStandaloneStackPresentation extends StackPresentation
         RGB blendwith = new RGB(255,255,255);
         RGB blended = blend(sel,blendwith,20);
         
-        toolbarBackground = new Color(parent.getDisplay(),blended);
+        toolbarBackground = new Color(blended);
         
         eBar.addExpandListener(new ExpandListener()
         {        

--- a/org.eclipse.nebula.presentations.shelf/src/org/eclipse/swt/nebula/presentations/shelf/PGroupStackPresentation.java
+++ b/org.eclipse.nebula.presentations.shelf/src/org/eclipse/swt/nebula/presentations/shelf/PGroupStackPresentation.java
@@ -75,7 +75,7 @@ public class PGroupStackPresentation extends StackPresentation
         RGB blendwith = new RGB(255,255,255);
         RGB blended = blend(sel,blendwith,20);
         
-        toolbarBackground = new Color(parent.getDisplay(),blended);
+        toolbarBackground = new Color(blended);
         
         group.addExpandListener(new ExpandListener()
         {        

--- a/org.eclipse.nebula.presentations.shelf/src/org/eclipse/swt/nebula/presentations/shelf/PShelfStackPresentation.java
+++ b/org.eclipse.nebula.presentations.shelf/src/org/eclipse/swt/nebula/presentations/shelf/PShelfStackPresentation.java
@@ -90,11 +90,11 @@ public class PShelfStackPresentation extends StackPresentation
         RGB blendwith = new RGB(255,255,255);
         RGB blended = blend(sel,blendwith,20);
         
-        toolbarBackground = new Color(parent.getDisplay(),blended);
+        toolbarBackground = new Color(blended);
         
         blended = blend(sel,blendwith,60);
         
-        border = new Color(parent.getDisplay(),blended);
+        border = new Color(blended);
         
         URL imageURL = Platform.getBundle("org.eclipse.swt.nebula.presentations.shelf").getResource("icons/view_menu.gif");
         menuTBImage = ImageDescriptor.createFromURL(imageURL).createImage();

--- a/org.eclipse.nebula.presentations.shelf/src/org/eclipse/swt/nebula/presentations/shelf/tab/GraphicUtils.java
+++ b/org.eclipse.nebula.presentations.shelf/src/org/eclipse/swt/nebula/presentations/shelf/tab/GraphicUtils.java
@@ -215,7 +215,7 @@ public class GraphicUtils
     public static Color createNewBlendedColor(RGB rgb1, RGB rgb2, int ratio)
     {
 
-        Color newColor = new Color(Display.getCurrent(), blend(rgb1, rgb2, ratio));
+        Color newColor = new Color(blend(rgb1, rgb2, ratio));
 
         return newColor;
 
@@ -224,14 +224,14 @@ public class GraphicUtils
     public static Color createNewBlendedColor(Color c1, Color c2, int ratio)
     {
 
-        Color newColor = new Color(Display.getCurrent(), blend(c1.getRGB(), c2.getRGB(), ratio));
+        Color newColor = new Color(blend(c1.getRGB(), c2.getRGB(), ratio));
 
         return newColor;
     }
 
     public static Color createNewReverseColor(Color c)
     {
-        Color newColor = new Color(Display.getCurrent(), 255 - c.getRed(), 255 - c.getGreen(),
+        Color newColor = new Color(255 - c.getRed(), 255 - c.getGreen(),
                                    255 - c.getBlue());
         return newColor;
     }
@@ -267,6 +267,6 @@ public class GraphicUtils
     public static Color createNewSaturatedColor(Color c, float saturation)
     {
         RGB newRGB = saturate(c.getRGB(), saturation);
-        return new Color(Display.getCurrent(), newRGB);
+        return new Color(newRGB);
     }
 }

--- a/widgets/badgedlabel/org.eclipse.nebula.widgets.badgedlabel.feature/feature.xml
+++ b/widgets/badgedlabel/org.eclipse.nebula.widgets.badgedlabel.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.nebula.widgets.badgedlabel.feature"
       label="Nebula Badged Label Widget"
-      version="1.0.0.qualifier"
+      version="1.1.0.qualifier"
       provider-name="Eclipse Nebula">
 
    <description url="http://eclipse.org/nebula">

--- a/widgets/badgedlabel/org.eclipse.nebula.widgets.badgedlabel.feature/pom.xml
+++ b/widgets/badgedlabel/org.eclipse.nebula.widgets.badgedlabel.feature/pom.xml
@@ -24,7 +24,7 @@ Contributors:
 
 	<artifactId>org.eclipse.nebula.widgets.badgedlabel.feature</artifactId>
 	<packaging>eclipse-feature</packaging>
-	<version>1.0.0-SNAPSHOT</version>
+	<version>1.1.0-SNAPSHOT</version>
 
 	<name>Nebula Badged Label Feature</name>
 

--- a/widgets/badgedlabel/org.eclipse.nebula.widgets.badgedlabel/META-INF/MANIFEST.MF
+++ b/widgets/badgedlabel/org.eclipse.nebula.widgets.badgedlabel/META-INF/MANIFEST.MF
@@ -7,5 +7,5 @@ Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.eclipse.nebula.widgets.badgedlabel
 Require-Bundle: org.eclipse.nebula.widgets.opal.commons,
- org.eclipse.swt
+ org.eclipse.swt;bundle-version="[3.115.0,4.0.0)"
 Automatic-Module-Name: org.eclipse.nebula.widgets.badgedlabel

--- a/widgets/badgedlabel/org.eclipse.nebula.widgets.badgedlabel/META-INF/MANIFEST.MF
+++ b/widgets/badgedlabel/org.eclipse.nebula.widgets.badgedlabel/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Nebula Badged Label Widget
 Bundle-SymbolicName: org.eclipse.nebula.widgets.badgedlabel
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.1.0.qualifier
 Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.eclipse.nebula.widgets.badgedlabel

--- a/widgets/badgedlabel/org.eclipse.nebula.widgets.badgedlabel/pom.xml
+++ b/widgets/badgedlabel/org.eclipse.nebula.widgets.badgedlabel/pom.xml
@@ -19,6 +19,7 @@ http://www.eclipse.org/legal/epl-v10.html
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.badgedlabel</artifactId>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/widgets/badgedlabel/org.eclipse.nebula.widgets.badgedlabel/src/org/eclipse/nebula/widgets/badgedlabel/BadgedLabel.java
+++ b/widgets/badgedlabel/org.eclipse.nebula.widgets.badgedlabel/src/org/eclipse/nebula/widgets/badgedlabel/BadgedLabel.java
@@ -113,14 +113,14 @@ public class BadgedLabel extends Canvas {
 		textColor = getDisplay().getSystemColor(SWT.COLOR_BLACK);
 		SWTGraphicUtil.addDisposer(this, textColor);
 
-		backgroundColor = new Color(getDisplay(), 247, 247, 247);
+		backgroundColor = new Color(247, 247, 247);
 		SWTGraphicUtil.addDisposer(this, backgroundColor);
 
-		borderColor = new Color(getDisplay(), 204, 204, 204);
+		borderColor = new Color(204, 204, 204);
 		SWTGraphicUtil.addDisposer(this, borderColor);
 
 		badgeForeground = getDisplay().getSystemColor(SWT.COLOR_WHITE);
-		badgeBackground = new Color(getDisplay(), 0, 123, 255);
+		badgeBackground = new Color(0, 123, 255);
 		SWTGraphicUtil.addDisposer(this, badgeBackground);
 	}
 
@@ -306,26 +306,26 @@ public class BadgedLabel extends Canvas {
 		badgeForeground = getDisplay().getSystemColor(SWT.COLOR_WHITE);
 		switch (color) {
 		case SWT.COLOR_BLUE:
-			badgeBackground = new Color(getDisplay(), 0, 123, 255);
+			badgeBackground = new Color(0, 123, 255);
 			break;
 		case SWT.COLOR_GRAY:
-			badgeBackground = new Color(getDisplay(), 108, 117, 125);
+			badgeBackground = new Color(108, 117, 125);
 			break;
 		case SWT.COLOR_GREEN:
-			badgeBackground = new Color(getDisplay(), 40, 167, 69);
+			badgeBackground = new Color(40, 167, 69);
 			break;
 		case SWT.COLOR_RED:
-			badgeBackground = new Color(getDisplay(), 220, 53, 69);
+			badgeBackground = new Color(220, 53, 69);
 			break;
 		case SWT.COLOR_YELLOW:
 			badgeForeground = getDisplay().getSystemColor(SWT.COLOR_BLACK);
-			badgeBackground = new Color(getDisplay(), 255, 193, 7);
+			badgeBackground = new Color(255, 193, 7);
 			break;
 		case SWT.COLOR_CYAN:
-			badgeBackground = new Color(getDisplay(), 23, 162, 184);
+			badgeBackground = new Color(23, 162, 184);
 			break;
 		default: // BLACK
-			badgeBackground = new Color(getDisplay(), 52, 58, 64);
+			badgeBackground = new Color(52, 58, 64);
 		}
 
 		SWTGraphicUtil.addDisposer(this, badgeBackground);

--- a/widgets/calendarcombo/org.eclipse.nebula.widgets.calendarcombo.feature/feature.xml
+++ b/widgets/calendarcombo/org.eclipse.nebula.widgets.calendarcombo.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.nebula.widgets.calendarcombo.feature"
       label="Nebula Calendar Combo Widget - Incubating"
-      version="1.0.0.qualifier"
+      version="1.1.0.qualifier"
       provider-name="Eclipse Nebula">
 
    <description url="http://www.eclipse.org/nebula/widgets/calendarcombo/calendarcombo.php">

--- a/widgets/calendarcombo/org.eclipse.nebula.widgets.calendarcombo.feature/pom.xml
+++ b/widgets/calendarcombo/org.eclipse.nebula.widgets.calendarcombo.feature/pom.xml
@@ -23,6 +23,7 @@ Contributors:
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.calendarcombo.feature</artifactId>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>eclipse-feature</packaging>
 
 	<name>Nebula Calendar Combo Feature</name>

--- a/widgets/calendarcombo/org.eclipse.nebula.widgets.calendarcombo/META-INF/MANIFEST.MF
+++ b/widgets/calendarcombo/org.eclipse.nebula.widgets.calendarcombo/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Nebula Calendar Combo Widget - Incubating
 Bundle-SymbolicName: org.eclipse.nebula.widgets.calendarcombo
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.1.0.qualifier
 Require-Bundle: org.eclipse.swt;bundle-version="[3.126.0,4.0.0)"
 Export-Package: org.eclipse.nebula.widgets.calendarcombo
 Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/widgets/calendarcombo/org.eclipse.nebula.widgets.calendarcombo/pom.xml
+++ b/widgets/calendarcombo/org.eclipse.nebula.widgets.calendarcombo/pom.xml
@@ -24,6 +24,7 @@ Contributors:
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.calendarcombo</artifactId>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/widgets/calendarcombo/org.eclipse.nebula.widgets.calendarcombo/src/org/eclipse/nebula/widgets/calendarcombo/ColorCache.java
+++ b/widgets/calendarcombo/org.eclipse.nebula.widgets.calendarcombo/src/org/eclipse/nebula/widgets/calendarcombo/ColorCache.java
@@ -304,7 +304,7 @@ public class ColorCache {
         Color color = (Color) mColorTable.get(rgb);
 
         if (color == null) {
-            color = new Color(Display.getCurrent(), rgb);
+            color = new Color(rgb);
             mColorTable.put(rgb, color);
         }
 

--- a/widgets/cdatetime/org.eclipse.nebula.widgets.cdatetime.feature/feature.xml
+++ b/widgets/cdatetime/org.eclipse.nebula.widgets.cdatetime.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.nebula.widgets.cdatetime.feature"
       label="Nebula CDateTime Widget"
-      version="1.5.1.qualifier"
+      version="1.6.0.qualifier"
       provider-name="Eclipse Nebula">
 
    <description url="http://www.eclipse.org/nebula/widgets/cdatetime">

--- a/widgets/cdatetime/org.eclipse.nebula.widgets.cdatetime.feature/pom.xml
+++ b/widgets/cdatetime/org.eclipse.nebula.widgets.cdatetime.feature/pom.xml
@@ -23,6 +23,7 @@ Contributors:
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.cdatetime.feature</artifactId>
+	<version>1.6.0-SNAPSHOT</version>
 	<packaging>eclipse-feature</packaging>
 
 </project>

--- a/widgets/cdatetime/org.eclipse.nebula.widgets.cdatetime/META-INF/MANIFEST.MF
+++ b/widgets/cdatetime/org.eclipse.nebula.widgets.cdatetime/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.nebula.widgets.cdatetime
-Bundle-Version: 1.5.1.qualifier
+Bundle-Version: 1.6.0.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/widgets/cdatetime/org.eclipse.nebula.widgets.cdatetime/pom.xml
+++ b/widgets/cdatetime/org.eclipse.nebula.widgets.cdatetime/pom.xml
@@ -23,6 +23,7 @@ Contributors:
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.cdatetime</artifactId>
+	<version>1.6.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/widgets/cdatetime/org.eclipse.nebula.widgets.cdatetime/src/org/eclipse/nebula/widgets/cdatetime/AnalogClockPainter.java
+++ b/widgets/cdatetime/org.eclipse.nebula.widgets.cdatetime/src/org/eclipse/nebula/widgets/cdatetime/AnalogClockPainter.java
@@ -192,8 +192,8 @@ class AnalogClockPainter implements IControlPainter {
 		int x = picker.dialCenter.x - picker.dialRadius;
 		int y = picker.dialCenter.y - picker.dialRadius;
 
-		Color c1 = new Color(e.display, 220, 220, 225);
-		Color c2 = new Color(e.display, 200, 200, 200);
+		Color c1 = new Color(220, 220, 225);
+		Color c2 = new Color(200, 200, 200);
 
 		Pattern p = new Pattern(e.display, 0, y, 0, y + dia,
 				e.display.getSystemColor(SWT.COLOR_WHITE), c1);

--- a/widgets/collapsiblebuttons/org.eclipse.nebula.widgets.collapsiblebuttons.feature/feature.xml
+++ b/widgets/collapsiblebuttons/org.eclipse.nebula.widgets.collapsiblebuttons.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.nebula.widgets.collapsiblebuttons.feature"
       label="Nebula Collapsible Buttons Widget - Incubating"
-      version="1.0.0.qualifier"
+      version="1.1.0.qualifier"
       provider-name="Eclipse Nebula">
 
    <description url="http://www.eclipse.org/nebula/widgets/collapsible/collapsible.php">

--- a/widgets/collapsiblebuttons/org.eclipse.nebula.widgets.collapsiblebuttons.feature/pom.xml
+++ b/widgets/collapsiblebuttons/org.eclipse.nebula.widgets.collapsiblebuttons.feature/pom.xml
@@ -19,6 +19,7 @@
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.collapsiblebuttons.feature</artifactId>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>eclipse-feature</packaging>
 
 	<name>Eclipse Collabsible Buttons Feature</name>

--- a/widgets/collapsiblebuttons/org.eclipse.nebula.widgets.collapsiblebuttons/META-INF/MANIFEST.MF
+++ b/widgets/collapsiblebuttons/org.eclipse.nebula.widgets.collapsiblebuttons/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Nebula Collapsible Buttons - Incubating
 Bundle-SymbolicName: org.eclipse.nebula.widgets.collapsiblebuttons
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.1.0.qualifier
 Require-Bundle: org.eclipse.swt;bundle-version="[3.115.0,4.0.0)"
 Export-Package: org.eclipse.nebula.widgets.collapsiblebuttons
 Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/widgets/collapsiblebuttons/org.eclipse.nebula.widgets.collapsiblebuttons/META-INF/MANIFEST.MF
+++ b/widgets/collapsiblebuttons/org.eclipse.nebula.widgets.collapsiblebuttons/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Nebula Collapsible Buttons - Incubating
 Bundle-SymbolicName: org.eclipse.nebula.widgets.collapsiblebuttons
 Bundle-Version: 1.0.0.qualifier
-Require-Bundle: org.eclipse.swt
+Require-Bundle: org.eclipse.swt;bundle-version="[3.115.0,4.0.0)"
 Export-Package: org.eclipse.nebula.widgets.collapsiblebuttons
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Vendor: Eclipse Nebula

--- a/widgets/collapsiblebuttons/org.eclipse.nebula.widgets.collapsiblebuttons/pom.xml
+++ b/widgets/collapsiblebuttons/org.eclipse.nebula.widgets.collapsiblebuttons/pom.xml
@@ -11,6 +11,7 @@
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.collapsiblebuttons</artifactId>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 	<name>Collapsible Buttons Widget</name>
 

--- a/widgets/collapsiblebuttons/org.eclipse.nebula.widgets.collapsiblebuttons/src/org/eclipse/nebula/widgets/collapsiblebuttons/ColorCache.java
+++ b/widgets/collapsiblebuttons/org.eclipse.nebula.widgets.collapsiblebuttons/src/org/eclipse/nebula/widgets/collapsiblebuttons/ColorCache.java
@@ -304,7 +304,7 @@ public class ColorCache {
         Color color = mColorTable.get(rgb);
 
         if (color == null) {
-            color = new Color(Display.getCurrent(), rgb);
+            color = new Color(rgb);
             mColorTable.put(rgb, color);
         }
 

--- a/widgets/compositetable/org.eclipse.nebula.widgets.compositetable.feature/feature.xml
+++ b/widgets/compositetable/org.eclipse.nebula.widgets.compositetable.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.nebula.widgets.compositetable.feature"
       label="Nebula Composite Table Widget"
-      version="1.0.0.qualifier"
+      version="1.1.0.qualifier"
       provider-name="Eclipse Nebula">
 
    <description url="http://www.eclipse.org/nebula/widgets/compositetable/compositetable.php">

--- a/widgets/compositetable/org.eclipse.nebula.widgets.compositetable.feature/pom.xml
+++ b/widgets/compositetable/org.eclipse.nebula.widgets.compositetable.feature/pom.xml
@@ -19,6 +19,7 @@
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.compositetable.feature</artifactId>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>eclipse-feature</packaging>
 
 	<name>Nebula Composite Table Feature</name>

--- a/widgets/compositetable/org.eclipse.nebula.widgets.compositetable/META-INF/MANIFEST.MF
+++ b/widgets/compositetable/org.eclipse.nebula.widgets.compositetable/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Nebula Compositetable
 Bundle-SymbolicName: org.eclipse.nebula.widgets.compositetable
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.1.0.qualifier
 Export-Package: org.eclipse.nebula.widgets.compositetable,
  org.eclipse.nebula.widgets.compositetable.day,
  org.eclipse.nebula.widgets.compositetable.month,

--- a/widgets/compositetable/org.eclipse.nebula.widgets.compositetable/META-INF/MANIFEST.MF
+++ b/widgets/compositetable/org.eclipse.nebula.widgets.compositetable/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Export-Package: org.eclipse.nebula.widgets.compositetable,
  org.eclipse.nebula.widgets.compositetable.day,
  org.eclipse.nebula.widgets.compositetable.month,
  org.eclipse.nebula.widgets.compositetable.timeeditor
-Require-Bundle: org.eclipse.swt,
+Require-Bundle: org.eclipse.swt;bundle-version="[3.115.0,4.0.0)",
  org.eclipse.jface
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Vendor: Eclipse Nebula

--- a/widgets/compositetable/org.eclipse.nebula.widgets.compositetable/pom.xml
+++ b/widgets/compositetable/org.eclipse.nebula.widgets.compositetable/pom.xml
@@ -10,6 +10,7 @@
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.compositetable</artifactId>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/widgets/compositetable/org.eclipse.nebula.widgets.compositetable/src/org/eclipse/nebula/widgets/compositetable/day/internal/DayEditorCalendarableItemControl.java
+++ b/widgets/compositetable/org.eclipse.nebula.widgets.compositetable/src/org/eclipse/nebula/widgets/compositetable/day/internal/DayEditorCalendarableItemControl.java
@@ -83,10 +83,10 @@ public class DayEditorCalendarableItemControl extends Canvas implements ICalenda
 		super(parent, style);
 		Display display = parent.getDisplay();
 
-		BACKGROUND_COLOR = new Color(display, lighten(saturate(display.getSystemColor(SWT.COLOR_TITLE_BACKGROUND_GRADIENT).getRGB(), .08f), .3f));
-		BORDER_COLOR = new Color(display, lighten(saturate(display.getSystemColor(SWT.COLOR_TITLE_BACKGROUND).getRGB(), .18f), .1f));
+		BACKGROUND_COLOR = new Color(lighten(saturate(display.getSystemColor(SWT.COLOR_TITLE_BACKGROUND_GRADIENT).getRGB(), .08f), .3f));
+		BORDER_COLOR = new Color(lighten(saturate(display.getSystemColor(SWT.COLOR_TITLE_BACKGROUND).getRGB(), .18f), .1f));
 		SELECTED_BACKGROUND_COLOR = display.getSystemColor(SWT.COLOR_WHITE);
-		SELECTED_BORDER_COLOR = new Color(display, saturate(BORDER_COLOR.getRGB(), .4f));
+		SELECTED_BORDER_COLOR = new Color(saturate(BORDER_COLOR.getRGB(), .4f));
 
 		initialize();
 	}

--- a/widgets/compositetable/org.eclipse.nebula.widgets.compositetable/src/org/eclipse/nebula/widgets/compositetable/day/internal/TimeSlot.java
+++ b/widgets/compositetable/org.eclipse.nebula.widgets.compositetable/src/org/eclipse/nebula/widgets/compositetable/day/internal/TimeSlot.java
@@ -91,10 +91,10 @@ public class TimeSlot extends Canvas {
 
 		CELL_BACKGROUND_WHITE = display.getSystemColor(SWT.COLOR_WHITE);
 		CELL_BORDER_EMPHASIZED = display.getSystemColor(SWT.COLOR_LIST_SELECTION);
-		CELL_BACKGROUND_LIGHT = new Color(display, new RGB(248, 248, 248));
-		CELL_BORDER_LIGHT = new Color(display, saturate(CELL_BORDER_EMPHASIZED.getRGB(), .2f));
-		TIME_BAR_COLOR = new Color(display, saturate(CELL_BORDER_EMPHASIZED.getRGB(), .1f));
-		FOCUS_RUBBERBAND = new Color(display, lighten(saturate(display.getSystemColor(SWT.COLOR_TITLE_BACKGROUND).getRGB(), .85f), -.333f));
+		CELL_BACKGROUND_LIGHT = new Color(new RGB(248, 248, 248));
+		CELL_BORDER_LIGHT = new Color(saturate(CELL_BORDER_EMPHASIZED.getRGB(), .2f));
+		TIME_BAR_COLOR = new Color(saturate(CELL_BORDER_EMPHASIZED.getRGB(), .1f));
+		FOCUS_RUBBERBAND = new Color(lighten(saturate(display.getSystemColor(SWT.COLOR_TITLE_BACKGROUND).getRGB(), .85f), -.333f));
 
 		setBackground(CELL_BACKGROUND_LIGHT);
 	}

--- a/widgets/compositetable/org.eclipse.nebula.widgets.compositetable/src/org/eclipse/nebula/widgets/compositetable/month/internal/Day.java
+++ b/widgets/compositetable/org.eclipse.nebula.widgets.compositetable/src/org/eclipse/nebula/widgets/compositetable/month/internal/Day.java
@@ -78,11 +78,11 @@ public class Day extends Canvas implements PaintListener, DisposeListener {
 		super(parent, style);
 
 		Display display = Display.getCurrent();
-		FOCUS_RUBBERBAND = new Color(display, lighten(saturate(display.getSystemColor(SWT.COLOR_TITLE_BACKGROUND).getRGB(), .85f), -.333f));
-		NONACTIVE_FOCUS_RUBBERBAND = new Color(display, lighten(saturate(display.getSystemColor(SWT.COLOR_TITLE_INACTIVE_BACKGROUND).getRGB(), .0f), -.333f));
+		FOCUS_RUBBERBAND = new Color(lighten(saturate(display.getSystemColor(SWT.COLOR_TITLE_BACKGROUND).getRGB(), .85f), -.333f));
+		NONACTIVE_FOCUS_RUBBERBAND = new Color(lighten(saturate(display.getSystemColor(SWT.COLOR_TITLE_INACTIVE_BACKGROUND).getRGB(), .0f), -.333f));
 		CURRENT_MONTH = display.getSystemColor(SWT.COLOR_WHITE);
-		OTHER_MONTH = new Color(display, new RGB(230, 230, 230));
-		CELL_BACKGROUND_LIGHT = new Color(display, new RGB(248, 248, 248));
+		OTHER_MONTH = new Color(new RGB(230, 230, 230));
+		CELL_BACKGROUND_LIGHT = new Color(new RGB(248, 248, 248));
 
 		initialize();
 

--- a/widgets/ctree/org.eclipse.nebula.widgets.ctree/META-INF/MANIFEST.MF
+++ b/widgets/ctree/org.eclipse.nebula.widgets.ctree/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Nebula CTree
 Bundle-SymbolicName: org.eclipse.nebula.widgets.ctree
-Bundle-Version: 0.8.0
+Bundle-Version: 0.9.0
 Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.swt;bundle-version="[3.126.0,4.0.0)"

--- a/widgets/ctree/org.eclipse.nebula.widgets.ctree/pom.xml
+++ b/widgets/ctree/org.eclipse.nebula.widgets.ctree/pom.xml
@@ -22,6 +22,7 @@ Contributors:
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.ctree</artifactId>
+	<version>0.9.0</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/widgets/ctree/org.eclipse.nebula.widgets.ctree/src/org/eclipse/nebula/widgets/ctree/CTreeCell.java
+++ b/widgets/ctree/org.eclipse.nebula.widgets.ctree/src/org/eclipse/nebula/widgets/ctree/CTreeCell.java
@@ -1232,7 +1232,7 @@ public class CTreeCell {
 					pointsWidth,
 					pointsWidth,
 					3, 3);
-			Color color = new Color(ctree.getDisplay(), 223, 229, 234);
+			Color color = new Color(223, 229, 234);
 			gc.setForeground(color);
 			gc.drawLine(
 					(int) x,
@@ -1253,7 +1253,7 @@ public class CTreeCell {
 					(int) y + pointsWidth-3
 			);
 			color.dispose();
-			color = new Color(ctree.getDisplay(), 196, 206, 216);
+			color = new Color(196, 206, 216);
 			gc.setForeground(color);
 			color.dispose();
 			gc.drawLine(

--- a/widgets/ctree/org.eclipse.nebula.widgets.ctree/src/org/eclipse/nebula/widgets/ctree/SColors.java
+++ b/widgets/ctree/org.eclipse.nebula.widgets.ctree/src/org/eclipse/nebula/widgets/ctree/SColors.java
@@ -106,7 +106,7 @@ public class SColors {
 	
 	public void setBorder(RGB rgb) {
 		if((display != null) && !display.isDisposed()) {
-			Color color = new Color(display, rgb);
+			Color color = new Color(rgb);
 			border = color;
 			disposable.add(color);
 		}
@@ -123,7 +123,7 @@ public class SColors {
 	
 	public void setGrid(RGB rgb) {
 		if((display != null) && !display.isDisposed()) {
-			Color color = new Color(display, rgb);
+			Color color = new Color(rgb);
 			grid = color;
 			disposable.add(color);
 		}
@@ -140,7 +140,7 @@ public class SColors {
 	
 	public void setItemBackgroundNormal(RGB rgb) {
 		if((display != null) && !display.isDisposed()) {
-			Color color = new Color(display, rgb);
+			Color color = new Color(rgb);
 			itemBackgroundNormal = color;
 			disposable.add(color);
 		}
@@ -157,7 +157,7 @@ public class SColors {
 	
 	public void setItemBackgroundSelected(RGB rgb) {
 		if((display != null) && !display.isDisposed()) {
-			Color color = new Color(display, rgb);
+			Color color = new Color(rgb);
 			itemBackgroundSelected = color;
 			disposable.add(color);
 		}
@@ -174,7 +174,7 @@ public class SColors {
 	
 	public void setItemBackgroundSelectedNoFocus(RGB rgb) {
 		if((display != null) && !display.isDisposed()) {
-			Color color = new Color(display, rgb);
+			Color color = new Color(rgb);
 			itemBackgroundSelectedNoFocus = color;
 			disposable.add(color);
 		}
@@ -191,7 +191,7 @@ public class SColors {
 	
 	public void setItemForegroundNormal(RGB rgb) {
 		if((display != null) && !display.isDisposed()) {
-			Color color = new Color(display, rgb);
+			Color color = new Color(rgb);
 			itemForegroundNormal = color;
 			disposable.add(color);
 		}
@@ -208,7 +208,7 @@ public class SColors {
 	
 	public void setItemForegroundSelected(RGB rgb) {
 		if((display != null) && !display.isDisposed()) {
-			Color color = new Color(display, rgb);
+			Color color = new Color(rgb);
 			itemForegroundSelected = color;
 			disposable.add(color);
 		}
@@ -225,7 +225,7 @@ public class SColors {
 	
 	public void setTableBackground(RGB rgb) {
 		if((display != null) && !display.isDisposed()) {
-			Color color = new Color(display, rgb);
+			Color color = new Color(rgb);
 			listBackground = color;
 			disposable.add(color);
 		}

--- a/widgets/cwt/org.eclipse.nebula.cwt.feature/feature.xml
+++ b/widgets/cwt/org.eclipse.nebula.cwt.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.nebula.cwt.feature"
       label="Nebula Custom Widget Toolkit"
-      version="1.1.0.qualifier"
+      version="1.2.0.qualifier"
       provider-name="Eclipse Nebula">
 
    <description url="http://eclipse.org/nebula">

--- a/widgets/cwt/org.eclipse.nebula.cwt.feature/pom.xml
+++ b/widgets/cwt/org.eclipse.nebula.cwt.feature/pom.xml
@@ -23,6 +23,7 @@ Contributors:
 	</parent>
 
 	<artifactId>org.eclipse.nebula.cwt.feature</artifactId>
+	<version>1.2.0-SNAPSHOT</version>
 	<packaging>eclipse-feature</packaging>
 
 </project>

--- a/widgets/cwt/org.eclipse.nebula.cwt/META-INF/MANIFEST.MF
+++ b/widgets/cwt/org.eclipse.nebula.cwt/META-INF/MANIFEST.MF
@@ -14,4 +14,4 @@ Export-Package: org.eclipse.nebula.cwt.animation,
  org.eclipse.nebula.cwt.svg,
  org.eclipse.nebula.cwt.v
 Automatic-Module-Name: org.eclipse.nebula.cwt
-Require-Bundle: org.eclipse.swt
+Require-Bundle: org.eclipse.swt;bundle-version="[3.115.0,4.0.0)"

--- a/widgets/cwt/org.eclipse.nebula.cwt/META-INF/MANIFEST.MF
+++ b/widgets/cwt/org.eclipse.nebula.cwt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Eclipse-ExtensibleAPI: true
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.nebula.cwt
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/widgets/cwt/org.eclipse.nebula.cwt/pom.xml
+++ b/widgets/cwt/org.eclipse.nebula.cwt/pom.xml
@@ -23,6 +23,7 @@ Contributors:
 	</parent>
 
 	<artifactId>org.eclipse.nebula.cwt</artifactId>
+	<version>1.2.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/widgets/cwt/org.eclipse.nebula.cwt/src/org/eclipse/nebula/cwt/svg/SvgFill.java
+++ b/widgets/cwt/org.eclipse.nebula.cwt/src/org/eclipse/nebula/cwt/svg/SvgFill.java
@@ -27,7 +27,7 @@ class SvgFill extends SvgPaint {
 		if(paintServer != null) {
 			paintServer.apply(false);
 		} else {
-			Color c = new Color(gc.getDevice(), color >> 16, (color & 0x00FF00) >> 8, color & 0x0000FF);
+			Color c = new Color(color >> 16, (color & 0x00FF00) >> 8, color & 0x0000FF);
 			gc.setBackground(c);
 			c.dispose();
 			gc.setFillRule(rule);

--- a/widgets/cwt/org.eclipse.nebula.cwt/src/org/eclipse/nebula/cwt/svg/SvgGradient.java
+++ b/widgets/cwt/org.eclipse.nebula.cwt/src/org/eclipse/nebula/cwt/svg/SvgGradient.java
@@ -99,7 +99,7 @@ class SvgGradient extends SvgElement {
 	}
 
 	private Color createColor(GC gc, int color) {
-		return new Color(gc.getDevice(), color >> 16, (color & 0x00FF00) >> 8, color & 0x0000FF);
+		return new Color(color >> 16, (color & 0x00FF00) >> 8, color & 0x0000FF);
 	}
 
 	public void dispose() {

--- a/widgets/cwt/org.eclipse.nebula.cwt/src/org/eclipse/nebula/cwt/svg/SvgStroke.java
+++ b/widgets/cwt/org.eclipse.nebula.cwt/src/org/eclipse/nebula/cwt/svg/SvgStroke.java
@@ -30,7 +30,7 @@ class SvgStroke extends SvgPaint {
 		if(paintServer != null) {
 			paintServer.apply(true);
 		} else {
-			Color c = new Color(gc.getDevice(), color >> 16, (color & 0x00FF00) >> 8, color & 0x0000FF);
+			Color c = new Color(color >> 16, (color & 0x00FF00) >> 8, color & 0x0000FF);
 			gc.setForeground(c);
 			c.dispose();
 			gc.setLineWidth((int)Math.ceil(width));

--- a/widgets/cwt/org.eclipse.nebula.cwt/src/org/eclipse/nebula/cwt/v/VButton.java
+++ b/widgets/cwt/org.eclipse.nebula.cwt/src/org/eclipse/nebula/cwt/v/VButton.java
@@ -49,10 +49,10 @@ public class VButton extends VControl {
 		addListener(SWT.MouseDown);
 		addListener(SWT.MouseUp);
 
-		defaultSelectedBorderColor = new Color(getDisplay(), 1, 85, 153);
-		defaultSelectedBackgroundColor = new Color(getDisplay(), 204, 228, 247);
-		defaultHoverBorderColor = new Color(getDisplay(), 1, 121, 215);
-		defaultHoverBackgroundColor = new Color(getDisplay(), 229, 241, 251);
+		defaultSelectedBorderColor = new Color(1, 85, 153);
+		defaultSelectedBackgroundColor = new Color(204, 228, 247);
+		defaultHoverBorderColor = new Color(1, 121, 215);
+		defaultHoverBackgroundColor = new Color(229, 241, 251);
 	}
 
 	public void dispose() {

--- a/widgets/datechooser/org.eclipse.nebula.widgets.datechooser.feature/feature.xml
+++ b/widgets/datechooser/org.eclipse.nebula.widgets.datechooser.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.nebula.widgets.datechooser.feature"
       label="Nebula Date Chooser Widget - Incubating"
-      version="1.0.0.qualifier"
+      version="1.1.0.qualifier"
       provider-name="Eclipse Nebula">
 
    <description url="http://eclipse.org/nebula">

--- a/widgets/datechooser/org.eclipse.nebula.widgets.datechooser.feature/pom.xml
+++ b/widgets/datechooser/org.eclipse.nebula.widgets.datechooser.feature/pom.xml
@@ -23,6 +23,7 @@ Contributors:
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.datechooser.feature</artifactId>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>eclipse-feature</packaging>
 
 </project>

--- a/widgets/datechooser/org.eclipse.nebula.widgets.datechooser/META-INF/MANIFEST.MF
+++ b/widgets/datechooser/org.eclipse.nebula.widgets.datechooser/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Nebula Date Chooser Widget - Incubating
 Bundle-SymbolicName: org.eclipse.nebula.widgets.datechooser
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.1.0.qualifier
 Export-Package: org.eclipse.nebula.widgets.datechooser
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Vendor: Eclipse Nebula

--- a/widgets/datechooser/org.eclipse.nebula.widgets.datechooser/pom.xml
+++ b/widgets/datechooser/org.eclipse.nebula.widgets.datechooser/pom.xml
@@ -23,6 +23,7 @@ Contributors:
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.datechooser</artifactId>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/widgets/datechooser/org.eclipse.nebula.widgets.datechooser/src/org/eclipse/nebula/widgets/datechooser/DateChooserTheme.java
+++ b/widgets/datechooser/org.eclipse.nebula.widgets.datechooser/src/org/eclipse/nebula/widgets/datechooser/DateChooserTheme.java
@@ -139,7 +139,7 @@ public class DateChooserTheme {
 		todayBackground = headerBackground;
 		todayForeground = headerForeground;
 		extraMonthForeground = gridLinesColor;
-		weekendForeground = new Color(display, 180, 0, 0);
+		weekendForeground = new Color(180, 0, 0);
 		focusColor = display.getSystemColor(SWT.COLOR_RED);
 	}
 
@@ -152,9 +152,9 @@ public class DateChooserTheme {
 		final Display display = Display.getCurrent();
 		final DateChooserTheme theme = new DateChooserTheme();
 
-		theme.headerBackground = new Color(display, 170, 190, 220);
+		theme.headerBackground = new Color(170, 190, 220);
 		theme.gridHeaderBackground = theme.headerBackground;
-		theme.dayCellBackground = new Color(display, 190, 220, 240);
+		theme.dayCellBackground = new Color(190, 220, 240);
 		theme.extraMonthForeground = display.getSystemColor(SWT.COLOR_DARK_GRAY);
 		theme.weekendForeground = display.getSystemColor(SWT.COLOR_RED);
 		theme.todayBackground = display.getSystemColor(SWT.COLOR_WHITE);
@@ -220,9 +220,9 @@ public class DateChooserTheme {
 		final Display display = Display.getCurrent();
 		final DateChooserTheme theme = new DateChooserTheme();
 
-		theme.headerBackground = new Color(display, 190, 180, 60);
+		theme.headerBackground = new Color(190, 180, 60);
 		theme.gridHeaderBackground = theme.headerBackground;
-		theme.dayCellBackground = new Color(display, 255, 255, 170);
+		theme.dayCellBackground = new Color(255, 255, 170);
 		theme.extraMonthForeground = display.getSystemColor(SWT.COLOR_DARK_GRAY);
 		theme.weekendForeground = display.getSystemColor(SWT.COLOR_RED);
 		theme.todayBackground = display.getSystemColor(SWT.COLOR_GRAY);

--- a/widgets/gallery/org.eclipse.nebula.widgets.gallery.feature/feature.xml
+++ b/widgets/gallery/org.eclipse.nebula.widgets.gallery.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.nebula.widgets.gallery.feature"
       label="Nebula Gallery Widget"
-      version="1.0.0.qualifier"
+      version="1.1.0.qualifier"
       provider-name="Eclipse Nebula">
 
    <description url="http://www.eclipse.org/nebula/widgets/gallery/gallery.php">

--- a/widgets/gallery/org.eclipse.nebula.widgets.gallery.feature/pom.xml
+++ b/widgets/gallery/org.eclipse.nebula.widgets.gallery.feature/pom.xml
@@ -24,7 +24,7 @@ Contributors:
 
 	<artifactId>org.eclipse.nebula.widgets.gallery.feature</artifactId>
 	<packaging>eclipse-feature</packaging>
-	<version>1.0.0-SNAPSHOT</version>
+	<version>1.1.0-SNAPSHOT</version>
 
 	<name>Nebula Gallery Feature</name>
 

--- a/widgets/gallery/org.eclipse.nebula.widgets.gallery/META-INF/MANIFEST.MF
+++ b/widgets/gallery/org.eclipse.nebula.widgets.gallery/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Nebula Gallery Widget
 Bundle-SymbolicName: org.eclipse.nebula.widgets.gallery
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.swt;bundle-version="[3.126.0,4.0.0)",
  org.eclipse.jface;resolution:=optional

--- a/widgets/gallery/org.eclipse.nebula.widgets.gallery/pom.xml
+++ b/widgets/gallery/org.eclipse.nebula.widgets.gallery/pom.xml
@@ -23,6 +23,7 @@ Contributors:
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.gallery</artifactId>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/widgets/gallery/org.eclipse.nebula.widgets.gallery/src/org/eclipse/nebula/animation/effects/SetColorEffect.java
+++ b/widgets/gallery/org.eclipse.nebula.widgets.gallery/src/org/eclipse/nebula/animation/effects/SetColorEffect.java
@@ -111,7 +111,7 @@ public class SetColorEffect extends AbstractEffect {
 
 		if (currentColor == null || !nextRGB.equals(currentColor.getRGB())) {
 
-			Color nextColor = new Color(Display.getCurrent(), nextRed,
+			Color nextColor = new Color(nextRed,
 					nextGreen, nextBlue);
 
 			// If this is the destination color, dispose the newly created color

--- a/widgets/gallery/org.eclipse.nebula.widgets.gallery/src/org/eclipse/nebula/widgets/gallery/DefaultGalleryItemRenderer.java
+++ b/widgets/gallery/org.eclipse.nebula.widgets.gallery/src/org/eclipse/nebula/widgets/gallery/DefaultGalleryItemRenderer.java
@@ -286,7 +286,7 @@ public class DefaultGalleryItemRenderer extends AbstractGalleryItemRenderer {
 			// Create new colors
 			for (int i = dropShadowsSize - 1; i >= 0; i--) {
 				int value = 255 - i * step;
-				Color c = new Color(Display.getDefault(), value, value, value);
+				Color c = new Color(value, value, value);
 				dropShadowsColors.add(c);
 			}
 		}

--- a/widgets/gallery/org.eclipse.nebula.widgets.gallery/src/org/eclipse/nebula/widgets/gallery/ListItemRenderer.java
+++ b/widgets/gallery/org.eclipse.nebula.widgets.gallery/src/org/eclipse/nebula/widgets/gallery/ListItemRenderer.java
@@ -272,7 +272,7 @@ public class ListItemRenderer extends AbstractGalleryItemRenderer {
 			// Create new colors
 			for (int i = dropShadowsSize - 1; i >= 0; i--) {
 				int value = 255 - i * step;
-				Color c = new Color(Display.getDefault(), value, value, value);
+				Color c = new Color(value, value, value);
 				dropShadowsColors.add(c);
 			}
 		}

--- a/widgets/ganttchart/org.eclipse.nebula.widgets.ganttchart.feature/feature.xml
+++ b/widgets/ganttchart/org.eclipse.nebula.widgets.ganttchart.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.nebula.widgets.ganttchart.feature"
       label="Nebula Gantt Chart Widget"
-      version="1.0.0.qualifier"
+      version="1.1.0.qualifier"
       provider-name="Eclipse Nebula">
 
    <description url="http://eclipse.org/nebula">

--- a/widgets/ganttchart/org.eclipse.nebula.widgets.ganttchart.feature/pom.xml
+++ b/widgets/ganttchart/org.eclipse.nebula.widgets.ganttchart.feature/pom.xml
@@ -23,6 +23,7 @@ Contributors:
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.ganttchart.feature</artifactId>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>eclipse-feature</packaging>
 
 	<name>Nebula Ganttchart Widget</name>

--- a/widgets/ganttchart/org.eclipse.nebula.widgets.ganttchart/META-INF/MANIFEST.MF
+++ b/widgets/ganttchart/org.eclipse.nebula.widgets.ganttchart/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Nebula Gantt Chart
 Bundle-SymbolicName: org.eclipse.nebula.widgets.ganttchart
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.1.0.qualifier
 Require-Bundle: org.eclipse.swt;bundle-version="[3.115.0,4.0.0)"
 Export-Package: org.eclipse.nebula.widgets.ganttchart,
  org.eclipse.nebula.widgets.ganttchart.dnd,

--- a/widgets/ganttchart/org.eclipse.nebula.widgets.ganttchart/META-INF/MANIFEST.MF
+++ b/widgets/ganttchart/org.eclipse.nebula.widgets.ganttchart/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Nebula Gantt Chart
 Bundle-SymbolicName: org.eclipse.nebula.widgets.ganttchart
 Bundle-Version: 1.0.0.qualifier
-Require-Bundle: org.eclipse.swt
+Require-Bundle: org.eclipse.swt;bundle-version="[3.115.0,4.0.0)"
 Export-Package: org.eclipse.nebula.widgets.ganttchart,
  org.eclipse.nebula.widgets.ganttchart.dnd,
  org.eclipse.nebula.widgets.ganttchart.print,

--- a/widgets/ganttchart/org.eclipse.nebula.widgets.ganttchart/pom.xml
+++ b/widgets/ganttchart/org.eclipse.nebula.widgets.ganttchart/pom.xml
@@ -23,6 +23,7 @@ Contributors:
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.ganttchart</artifactId>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/widgets/ganttchart/org.eclipse.nebula.widgets.ganttchart/src/org/eclipse/nebula/widgets/ganttchart/ColorCache.java
+++ b/widgets/ganttchart/org.eclipse.nebula.widgets.ganttchart/src/org/eclipse/nebula/widgets/ganttchart/ColorCache.java
@@ -112,7 +112,7 @@ public final class ColorCache {
         Color color = (Color) _cache.get(rgb);
 
         if (color == null) {
-            color = new Color(Display.getCurrent(), rgb);
+            color = new Color(rgb);
             _cache.put(rgb, color);
         }
 

--- a/widgets/geomap/org.eclipse.nebula.widgets.geomap.feature/feature.xml
+++ b/widgets/geomap/org.eclipse.nebula.widgets.geomap.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.nebula.widgets.geomap.feature"
       label="Nebula GeoMap Widget and Viewer"
-      version="1.0.0.qualifier"
+      version="1.1.0.qualifier"
       provider-name="Eclipse Nebula">
 
    <description url="http://www.eclipse.org/nebula/widgets/geomap">

--- a/widgets/geomap/org.eclipse.nebula.widgets.geomap.feature/pom.xml
+++ b/widgets/geomap/org.eclipse.nebula.widgets.geomap.feature/pom.xml
@@ -22,6 +22,7 @@ Contributors:
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.geomap.feature</artifactId>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>eclipse-feature</packaging>
 
 </project>

--- a/widgets/geomap/org.eclipse.nebula.widgets.geomap/META-INF/MANIFEST.MF
+++ b/widgets/geomap/org.eclipse.nebula.widgets.geomap/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.nebula.widgets.geomap
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.1.0.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/widgets/geomap/org.eclipse.nebula.widgets.geomap/META-INF/MANIFEST.MF
+++ b/widgets/geomap/org.eclipse.nebula.widgets.geomap/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11
-Require-Bundle: org.eclipse.swt,
+Require-Bundle: org.eclipse.swt;bundle-version="[3.115.0,4.0.0)",
  org.eclipse.jface;bundle-version="3.7.0";resolution:=optional,
  org.eclipse.draw2d;bundle-version="3.9.0";resolution:=optional
 Export-Package: org.eclipse.nebula.widgets.geomap,

--- a/widgets/geomap/org.eclipse.nebula.widgets.geomap/pom.xml
+++ b/widgets/geomap/org.eclipse.nebula.widgets.geomap/pom.xml
@@ -23,6 +23,7 @@ Contributors:
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.geomap</artifactId>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/widgets/geomap/org.eclipse.nebula.widgets.geomap/src/org/eclipse/nebula/widgets/geomap/internal/GeoMapHelper.java
+++ b/widgets/geomap/org.eclipse.nebula.widgets.geomap/src/org/eclipse/nebula/widgets/geomap/internal/GeoMapHelper.java
@@ -138,8 +138,8 @@ public class GeoMapHelper implements GeoMapPositioned, GeoMapHelperListener {
 				super.clear();
 			}
 		});
-		waitBackground = new Color(display, 0x88, 0x88, 0x88);
-		waitForeground = new Color(display, 0x77, 0x77, 0x77);
+		waitBackground = new Color(0x88, 0x88, 0x88);
+		waitForeground = new Color(0x77, 0x77, 0x77);
 
 		setZoom(zoom);
 		setMapPosition(mapPosition.x, mapPosition.y);

--- a/widgets/geomap/org.eclipse.nebula.widgets.geomap/src/org/eclipse/nebula/widgets/geomap/internal/geomapbrowser/HeaderControl.java
+++ b/widgets/geomap/org.eclipse.nebula.widgets.geomap/src/org/eclipse/nebula/widgets/geomap/internal/geomapbrowser/HeaderControl.java
@@ -52,7 +52,7 @@ public class HeaderControl extends Canvas {
 		addDisposeListener(e -> onDispose(e));
 
 		font = new Font(getDisplay(), "Tahoma", 10, SWT.BOLD);
-		foreground = new Color(getDisplay(), 87, 166, 212);
+		foreground = new Color(87, 166, 212);
 		measureString("M");
 	}
 

--- a/widgets/geomap/org.eclipse.nebula.widgets.geomap/src/org/eclipse/nebula/widgets/geomap/internal/geomapbrowser/TitleControl.java
+++ b/widgets/geomap/org.eclipse.nebula.widgets.geomap/src/org/eclipse/nebula/widgets/geomap/internal/geomapbrowser/TitleControl.java
@@ -50,10 +50,10 @@ public class TitleControl extends Canvas {
 		addDisposeListener(e -> onDispose(e));
 
 		font = new Font(getDisplay(), "Tahoma", 10, SWT.BOLD);
-		gradient1Color = new Color(getDisplay(), 255, 255, 255);
-		gradient2Color = new Color(getDisplay(), 205, 224, 244);
-		bottomLineColor = new Color(getDisplay(), 200, 195, 216);
-		writingColor = new Color(getDisplay(), 60, 60, 60);
+		gradient1Color = new Color(255, 255, 255);
+		gradient2Color = new Color(205, 224, 244);
+		bottomLineColor = new Color(200, 195, 216);
+		writingColor = new Color(60, 60, 60);
 		this.image = image;
 
 		measureSize("M");

--- a/widgets/grid/org.eclipse.nebula.widgets.grid.test/META-INF/MANIFEST.MF
+++ b/widgets/grid/org.eclipse.nebula.widgets.grid.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-Vendor: %Bundle-Vendor
 Bundle-SymbolicName: org.eclipse.nebula.widgets.grid.test
-Bundle-Version: 0.3.0.qualifier
+Bundle-Version: 0.4.0.qualifier
 Require-Bundle: org.junit;bundle-version="4.8.2"
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/widgets/grid/org.eclipse.nebula.widgets.grid.test/src/org/eclipse/nebula/widgets/grid/GridItem_Test.java
+++ b/widgets/grid/org.eclipse.nebula.widgets.grid.test/src/org/eclipse/nebula/widgets/grid/GridItem_Test.java
@@ -482,7 +482,7 @@ public class GridItem_Test {
   @Test
   public void testGetBackground() {
     GridItem item = new GridItem( grid, SWT.NONE );
-    Color background = new Color( display, 0, 0, 255 );
+    Color background = new Color(0, 0, 255 );
     item.setBackground( background );
     assertSame( background, item.getBackground() );
   }
@@ -490,7 +490,7 @@ public class GridItem_Test {
   @Test( expected = IllegalArgumentException.class )
   public void testSetBackground_DisposedFont() {
     GridItem item = new GridItem( grid, SWT.NONE );
-    Color background = new Color( display, 0, 0, 255 );
+    Color background = new Color(0, 0, 255 );
     background.dispose();
     item.setBackground( background );
   }
@@ -499,7 +499,7 @@ public class GridItem_Test {
   public void testGetBackgroundByIndex() {
     createGridColumns( grid, 3, SWT.NONE );
     GridItem item = new GridItem( grid, SWT.NONE );
-    Color background = new Color( display, 0, 0, 255 );
+    Color background = new Color(0, 0, 255 );
     item.setBackground( 1, background );
     assertSame( grid.getBackground(), item.getBackground( 0 ) );
     assertSame( background, item.getBackground( 1 ) );
@@ -517,7 +517,7 @@ public class GridItem_Test {
   public void testSetBackgroundByIndex_DisposedFont() {
     createGridColumns( grid, 3, SWT.NONE );
     GridItem item = new GridItem( grid, SWT.NONE );
-    Color background = new Color( display, 0, 0, 255 );
+    Color background = new Color(0, 0, 255 );
     background.dispose();
     item.setBackground( 1, background );
   }
@@ -531,7 +531,7 @@ public class GridItem_Test {
   @Test
   public void testGetForeground() {
     GridItem item = new GridItem( grid, SWT.NONE );
-    Color foreground = new Color( display, 0, 0, 255 );
+    Color foreground = new Color(0, 0, 255 );
     item.setForeground( foreground );
     assertSame( foreground, item.getForeground() );
   }
@@ -539,7 +539,7 @@ public class GridItem_Test {
   @Test( expected = IllegalArgumentException.class )
   public void testSetForeground_DisposedFont() {
     GridItem item = new GridItem( grid, SWT.NONE );
-    Color foreground = new Color( display, 0, 0, 255 );
+    Color foreground = new Color(0, 0, 255 );
     foreground.dispose();
     item.setForeground( foreground );
   }
@@ -548,7 +548,7 @@ public class GridItem_Test {
   public void testGetForegroundByIndex() {
     createGridColumns( grid, 3, SWT.NONE );
     GridItem item = new GridItem( grid, SWT.NONE );
-    Color foreground = new Color( display, 0, 0, 255 );
+    Color foreground = new Color(0, 0, 255 );
     item.setForeground( 1, foreground );
     assertSame( grid.getForeground(), item.getForeground( 0 ) );
     assertSame( foreground, item.getForeground( 1 ) );
@@ -566,7 +566,7 @@ public class GridItem_Test {
   public void testSetForegroundByIndex_DisposedFont() {
     createGridColumns( grid, 3, SWT.NONE );
     GridItem item = new GridItem( grid, SWT.NONE );
-    Color foreground = new Color( display, 0, 0, 255 );
+    Color foreground = new Color(0, 0, 255 );
     foreground.dispose();
     item.setForeground( 1, foreground );
   }
@@ -575,8 +575,8 @@ public class GridItem_Test {
   public void testClear() {
     GridItem item = new GridItem( grid, SWT.NONE );
     Font font = new Font( display, "Arial", 20, SWT.BOLD );
-    Color background = new Color( display, 0, 255, 0 );
-    Color foreground = new Color( display, 0, 0, 255 );
+    Color background = new Color(0, 255, 0 );
+    Color foreground = new Color(0, 0, 255 );
     item.setFont( font );
     item.setBackground( background );
     item.setForeground( foreground );

--- a/widgets/led/org.eclipse.nebula.widgets.led.feature/feature.xml
+++ b/widgets/led/org.eclipse.nebula.widgets.led.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.nebula.widgets.led.feature"
       label="Nebula LED Widget"
-      version="1.0.0.qualifier"
+      version="1.1.0.qualifier"
       provider-name="Eclipse Nebula">
 
    <description url="http://eclipse.org/nebula">

--- a/widgets/led/org.eclipse.nebula.widgets.led.feature/pom.xml
+++ b/widgets/led/org.eclipse.nebula.widgets.led.feature/pom.xml
@@ -24,7 +24,7 @@ Contributors:
 
 	<artifactId>org.eclipse.nebula.widgets.led.feature</artifactId>
 	<packaging>eclipse-feature</packaging>
-	<version>1.0.0-SNAPSHOT</version>
+	<version>1.1.0-SNAPSHOT</version>
 
 	<name>Nebula Badged Label Feature</name>
 

--- a/widgets/led/org.eclipse.nebula.widgets.led.snippets/META-INF/MANIFEST.MF
+++ b/widgets/led/org.eclipse.nebula.widgets.led.snippets/META-INF/MANIFEST.MF
@@ -6,5 +6,5 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.nebula.widgets.led;bundle-version="1.0.0",
- org.eclipse.swt
+ org.eclipse.swt;bundle-version="[3.115.0,4.0.0)"
 Automatic-Module-Name: org.eclipse.nebula.widgets.led.snippets

--- a/widgets/led/org.eclipse.nebula.widgets.led.snippets/META-INF/MANIFEST.MF
+++ b/widgets/led/org.eclipse.nebula.widgets.led.snippets/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Nebula LED Snippets
 Bundle-SymbolicName: org.eclipse.nebula.widgets.led.snippets
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.1.0.qualifier
 Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.nebula.widgets.led;bundle-version="1.0.0",

--- a/widgets/led/org.eclipse.nebula.widgets.led.snippets/pom.xml
+++ b/widgets/led/org.eclipse.nebula.widgets.led.snippets/pom.xml
@@ -19,6 +19,7 @@ http://www.eclipse.org/legal/epl-v10.html
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.led.snippets</artifactId>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/widgets/led/org.eclipse.nebula.widgets.led.snippets/src/org/eclipse/nebula/widgets/led/LEDSnippet.java
+++ b/widgets/led/org.eclipse.nebula.widgets.led.snippets/src/org/eclipse/nebula/widgets/led/LEDSnippet.java
@@ -66,11 +66,11 @@ public class LEDSnippet {
 		LED led = new LED(top, SWT.ICON);
 		led.setLayoutData(new GridData(GridData.END, GridData.FILL, true, true, 1, 2));
 		led.setCharacter(LEDCharacter.CLEAR);
-		Color idleColor = new Color(shell.getDisplay(), 60, 60, 60);
+		Color idleColor = new Color(60, 60, 60);
 		led.setIdleColor(idleColor);
 		SWTGraphicUtil.addDisposer(led, idleColor);
 
-		Color selectedColor = new Color(shell.getDisplay(), 255, 0, 0);
+		Color selectedColor = new Color(255, 0, 0);
 		led.setSelectedColor(selectedColor);
 		SWTGraphicUtil.addDisposer(led, selectedColor);
 

--- a/widgets/led/org.eclipse.nebula.widgets.led/META-INF/MANIFEST.MF
+++ b/widgets/led/org.eclipse.nebula.widgets.led/META-INF/MANIFEST.MF
@@ -7,5 +7,5 @@ Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.eclipse.nebula.widgets.led
 Require-Bundle: org.eclipse.nebula.widgets.opal.commons;visibility:=reexport,
- org.eclipse.swt
+ org.eclipse.swt;bundle-version="[3.115.0,4.0.0)"
 Automatic-Module-Name: org.eclipse.nebula.widgets.led

--- a/widgets/led/org.eclipse.nebula.widgets.led/META-INF/MANIFEST.MF
+++ b/widgets/led/org.eclipse.nebula.widgets.led/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Nebula LED Widget
 Bundle-SymbolicName: org.eclipse.nebula.widgets.led
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.1.0.qualifier
 Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.eclipse.nebula.widgets.led

--- a/widgets/led/org.eclipse.nebula.widgets.led/pom.xml
+++ b/widgets/led/org.eclipse.nebula.widgets.led/pom.xml
@@ -19,6 +19,7 @@ http://www.eclipse.org/legal/epl-v10.html
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.led</artifactId>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/widgets/led/org.eclipse.nebula.widgets.led/src/org/eclipse/nebula/widgets/led/BaseLED.java
+++ b/widgets/led/org.eclipse.nebula.widgets.led/src/org/eclipse/nebula/widgets/led/BaseLED.java
@@ -72,11 +72,11 @@ public abstract class BaseLED extends Canvas {
 		setBackground(getDisplay().getSystemColor(SWT.COLOR_BLACK));
 		addListener(SWT.Paint, e -> onPaint(e));
 
-		Color defaultIdleColor = new Color(getDisplay(), 0, 29, 29);
+		Color defaultIdleColor = new Color(0, 29, 29);
 		SWTGraphicUtil.addDisposer(this, defaultIdleColor);
 		idleColor = defaultIdleColor;
 
-		Color defaultSelectedColor = new Color(getDisplay(), 148, 237, 147);
+		Color defaultSelectedColor = new Color(148, 237, 147);
 		SWTGraphicUtil.addDisposer(this, defaultSelectedColor);
 		selectedColor = defaultSelectedColor;
 	}

--- a/widgets/nebulatoolbar/META-INF/MANIFEST.MF
+++ b/widgets/nebulatoolbar/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Nebula Toolbar
 Bundle-SymbolicName: org.eclipse.nebula.widgets.nebulatoolbar
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.1.0.qualifier
 Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: J2SE-1.5
 Require-Bundle: org.eclipse.swt;bundle-version="[3.115.0,4.0.0)"

--- a/widgets/nebulatoolbar/META-INF/MANIFEST.MF
+++ b/widgets/nebulatoolbar/META-INF/MANIFEST.MF
@@ -5,5 +5,5 @@ Bundle-SymbolicName: org.eclipse.nebula.widgets.nebulatoolbar
 Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: J2SE-1.5
-Require-Bundle: org.eclipse.swt
+Require-Bundle: org.eclipse.swt;bundle-version="[3.115.0,4.0.0)"
 Export-Package: org.eclipse.nebula.widgets.nebulatoolbar

--- a/widgets/nebulatoolbar/src/org/eclipse/nebula/widgets/nebulatoolbar/NebulaToolbar.java
+++ b/widgets/nebulatoolbar/src/org/eclipse/nebula/widgets/nebulatoolbar/NebulaToolbar.java
@@ -831,13 +831,13 @@ public class NebulaToolbar extends Canvas
 		Rectangle rect = getClientArea();
 		Device device = gc.getDevice();
 
-		Color c1 = new Color(device, 249, 252, 255);
-		Color c2 = new Color(device, 230, 240, 250);
-		Color c3 = new Color(device, 220, 230, 244);
-		Color c4 = new Color(device, 221, 233, 247);
+		Color c1 = new Color(249, 252, 255);
+		Color c2 = new Color(230, 240, 250);
+		Color c3 = new Color(220, 230, 244);
+		Color c4 = new Color(221, 233, 247);
 
-		Color ca = new Color(device, 205, 218, 234);
-		Color cb = new Color(device, 160, 175, 195);
+		Color ca = new Color(205, 218, 234);
+		Color cb = new Color(160, 175, 195);
 
 		int middle = (int) Math.ceil(rect.height / 2);
 
@@ -883,9 +883,9 @@ public class NebulaToolbar extends Canvas
 		Rectangle rect = getClientArea();
 		Device device = gc.getDevice();
 
-		Color c1 = new Color(device, 5, 72, 117);
-		Color c2 = new Color(device, 25, 108, 119);
-		Color c3 = new Color(device, 28, 122, 134);
+		Color c1 = new Color(5, 72, 117);
+		Color c2 = new Color(25, 108, 119);
+		Color c3 = new Color(28, 122, 134);
 		Color wh = getDisplay().getSystemColor(SWT.COLOR_WHITE);
 
 		int middle = (int) Math.ceil(rect.height / 2);

--- a/widgets/nebulatoolbar/src/org/eclipse/nebula/widgets/nebulatoolbar/ToolbarItem.java
+++ b/widgets/nebulatoolbar/src/org/eclipse/nebula/widgets/nebulatoolbar/ToolbarItem.java
@@ -296,13 +296,13 @@ public class ToolbarItem extends Item
 
 		Color defaultForegroundColor = gc.getForeground();
 
-		Color darkBorder = new Color(gc.getDevice(), 179, 196, 216);
-		Color lightBorder = new Color(gc.getDevice(), 252, 253, 254);
+		Color darkBorder = new Color(179, 196, 216);
+		Color lightBorder = new Color(252, 253, 254);
 
 		if (pushedDown)
 		{
 			darkBorder.dispose();
-			darkBorder = new Color(gc.getDevice(), 181, 197, 217);
+			darkBorder = new Color(181, 197, 217);
 		}
 
 		if (pushedDown || hovered || selected)
@@ -327,17 +327,17 @@ public class ToolbarItem extends Item
 
 				if (pushedDown)
 				{
-					c1 = new Color(gc.getDevice(), 201, 212, 228);
-					c2 = new Color(gc.getDevice(), 216, 228, 241);
-					c3 = new Color(gc.getDevice(), 207, 219, 236);
-					c4 = new Color(gc.getDevice(), 207, 220, 237);
+					c1 = new Color(201, 212, 228);
+					c2 = new Color(216, 228, 241);
+					c3 = new Color(207, 219, 236);
+					c4 = new Color(207, 220, 237);
 				}
 				else
 				{
-					c1 = new Color(gc.getDevice(), 248, 251, 254);
-					c2 = new Color(gc.getDevice(), 237, 242, 250);
-					c3 = new Color(gc.getDevice(), 215, 228, 244);
-					c4 = new Color(gc.getDevice(), 193, 210, 232);
+					c1 = new Color(248, 251, 254);
+					c2 = new Color(237, 242, 250);
+					c3 = new Color(215, 228, 244);
+					c4 = new Color(193, 210, 232);
 				}
 
 				int middle = y + 12;

--- a/widgets/opal/calculator/org.eclipse.nebula.widgets.opal.calculator.feature/feature.xml
+++ b/widgets/opal/calculator/org.eclipse.nebula.widgets.opal.calculator.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.nebula.widgets.opal.calculator.feature"
       label="Nebula Opal Calculator Widget"
-      version="1.0.0.qualifier"
+      version="1.1.0.qualifier"
       provider-name="Eclipse Nebula">
 
    <description url="http://eclipse.org/nebula">

--- a/widgets/opal/calculator/org.eclipse.nebula.widgets.opal.calculator.feature/pom.xml
+++ b/widgets/opal/calculator/org.eclipse.nebula.widgets.opal.calculator.feature/pom.xml
@@ -24,7 +24,7 @@ Contributors:
 
 	<artifactId>org.eclipse.nebula.widgets.opal.calculator.feature</artifactId>
 	<packaging>eclipse-feature</packaging>
-	<version>1.0.0-SNAPSHOT</version>
+	<version>1.1.0-SNAPSHOT</version>
 
 	<name>Calculator Feature</name>
 

--- a/widgets/opal/calculator/org.eclipse.nebula.widgets.opal.calculator/META-INF/MANIFEST.MF
+++ b/widgets/opal/calculator/org.eclipse.nebula.widgets.opal.calculator/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Nebula Opal Calculator Widget
 Bundle-SymbolicName: org.eclipse.nebula.widgets.opal.calculator
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.1.0.qualifier
 Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.nebula.widgets.opal.commons;bundle-version="1.0.0";visibility:=reexport,

--- a/widgets/opal/calculator/org.eclipse.nebula.widgets.opal.calculator/META-INF/MANIFEST.MF
+++ b/widgets/opal/calculator/org.eclipse.nebula.widgets.opal.calculator/META-INF/MANIFEST.MF
@@ -6,6 +6,6 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.nebula.widgets.opal.commons;bundle-version="1.0.0";visibility:=reexport,
- org.eclipse.swt
+ org.eclipse.swt;bundle-version="[3.115.0,4.0.0)"
 Export-Package: org.eclipse.nebula.widgets.opal.calculator
 Automatic-Module-Name: org.eclipse.nebula.widgets.opal.calculator

--- a/widgets/opal/calculator/org.eclipse.nebula.widgets.opal.calculator/pom.xml
+++ b/widgets/opal/calculator/org.eclipse.nebula.widgets.opal.calculator/pom.xml
@@ -19,6 +19,7 @@ http://www.eclipse.org/legal/epl-v10.html
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.opal.calculator</artifactId>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/widgets/opal/calculator/org.eclipse.nebula.widgets.opal.calculator/src/org/eclipse/nebula/widgets/opal/calculator/CalculatorButtonsComposite.java
+++ b/widgets/opal/calculator/org.eclipse.nebula.widgets.opal.calculator/src/org/eclipse/nebula/widgets/opal/calculator/CalculatorButtonsComposite.java
@@ -58,8 +58,8 @@ class CalculatorButtonsComposite extends Composite {
 	CalculatorButtonsComposite(final Composite parent, final int style) {
 		super(parent, style);
 		setLayout(new GridLayout(5, false));
-		darkRedColor = new Color(getDisplay(), 139, 0, 0);
-		darkBlueColor = new Color(getDisplay(), 0, 0, 139);
+		darkRedColor = new Color(139, 0, 0);
+		darkBlueColor = new Color(0, 0, 139);
 		createButtons();
 
 		SWTGraphicUtil.addDisposer(this, darkBlueColor);

--- a/widgets/opal/dialog/org.eclipse.nebula.widgets.opal.dialog.feature/feature.xml
+++ b/widgets/opal/dialog/org.eclipse.nebula.widgets.opal.dialog.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.nebula.widgets.opal.dialog.feature"
       label="Nebula Opal Dialog Widget"
-      version="1.0.0.qualifier"
+      version="1.1.0.qualifier"
       provider-name="Eclipse Nebula">
 
    <description url="http://eclipse.org/nebula">

--- a/widgets/opal/dialog/org.eclipse.nebula.widgets.opal.dialog.feature/pom.xml
+++ b/widgets/opal/dialog/org.eclipse.nebula.widgets.opal.dialog.feature/pom.xml
@@ -24,7 +24,7 @@ Contributors:
 
 	<artifactId>org.eclipse.nebula.widgets.opal.dialog.feature</artifactId>
 	<packaging>eclipse-feature</packaging>
-	<version>1.0.0-SNAPSHOT</version>
+	<version>1.1.0-SNAPSHOT</version>
 
 	<name>Dialog Feature</name>
 

--- a/widgets/opal/dialog/org.eclipse.nebula.widgets.opal.dialog/META-INF/MANIFEST.MF
+++ b/widgets/opal/dialog/org.eclipse.nebula.widgets.opal.dialog/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Nebula Opal Dialog
 Bundle-SymbolicName: org.eclipse.nebula.widgets.opal.dialog
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Vendor: Eclipse Nebula
 Require-Bundle: org.eclipse.nebula.widgets.opal.commons;bundle-version="1.0.0";visibility:=reexport,

--- a/widgets/opal/dialog/org.eclipse.nebula.widgets.opal.dialog/META-INF/MANIFEST.MF
+++ b/widgets/opal/dialog/org.eclipse.nebula.widgets.opal.dialog/META-INF/MANIFEST.MF
@@ -6,6 +6,6 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Vendor: Eclipse Nebula
 Require-Bundle: org.eclipse.nebula.widgets.opal.commons;bundle-version="1.0.0";visibility:=reexport,
- org.eclipse.swt
+ org.eclipse.swt;bundle-version="[3.115.0,4.0.0)"
 Export-Package: org.eclipse.nebula.widgets.opal.dialog
 Automatic-Module-Name: org.eclipse.nebula.widgets.opal.dialog

--- a/widgets/opal/dialog/org.eclipse.nebula.widgets.opal.dialog/pom.xml
+++ b/widgets/opal/dialog/org.eclipse.nebula.widgets.opal.dialog/pom.xml
@@ -19,6 +19,7 @@ http://www.eclipse.org/legal/epl-v10.html
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.opal.dialog</artifactId>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/widgets/opal/dialog/org.eclipse.nebula.widgets.opal.dialog/src/org/eclipse/nebula/widgets/opal/dialog/ChoiceWidget.java
+++ b/widgets/opal/dialog/org.eclipse.nebula.widgets.opal.dialog/src/org/eclipse/nebula/widgets/opal/dialog/ChoiceWidget.java
@@ -121,7 +121,7 @@ public class ChoiceWidget extends Composite {
 	 * Build the instruction
 	 */
 	private void buildInstruction() {
-		final Color color = new Color(Display.getCurrent(), 35, 107, 178);
+		final Color color = new Color(35, 107, 178);
 		SWTGraphicUtil.addDisposer(this, color);
 
 		instruction = new Label(this, SWT.NONE);
@@ -218,8 +218,8 @@ public class ChoiceWidget extends Composite {
 			gc.drawRectangle(rect.x, rect.y, rect.width, rect.height);
 		} else {
 			// The mouse is over OR the item is selected
-			final Color gradientColor = inside ? new Color(getDisplay(), 220, 231, 243) : new Color(getDisplay(), 241, 241, 241);
-			final Color borderColor = inside ? new Color(getDisplay(), 35, 107, 178) : new Color(getDisplay(), 192, 192, 192);
+			final Color gradientColor = inside ? new Color(220, 231, 243) : new Color(241, 241, 241);
+			final Color borderColor = inside ? new Color(35, 107, 178) : new Color(192, 192, 192);
 
 			gc.setForeground(getDisplay().getSystemColor(SWT.COLOR_WHITE));
 			gc.setBackground(gradientColor);

--- a/widgets/opal/dialog/org.eclipse.nebula.widgets.opal.dialog/src/org/eclipse/nebula/widgets/opal/dialog/DialogArea.java
+++ b/widgets/opal/dialog/org.eclipse.nebula.widgets.opal.dialog/src/org/eclipse/nebula/widgets/opal/dialog/DialogArea.java
@@ -101,7 +101,7 @@ abstract class DialogArea {
 	 * @return the title's color (blue)
 	 */
 	protected Color getTitleColor() {
-		final Color color = new Color(Display.getCurrent(), 35, 107, 178);
+		final Color color = new Color(35, 107, 178);
 		SWTGraphicUtil.addDisposer(parent.shell, color);
 		return color;
 	}
@@ -110,7 +110,7 @@ abstract class DialogArea {
 	 * @return the grey color
 	 */
 	protected Color getGreyColor() {
-		final Color color = new Color(Display.getCurrent(), 240, 240, 240);
+		final Color color = new Color(240, 240, 240);
 		SWTGraphicUtil.addDisposer(parent.shell, color);
 		return color;
 	}

--- a/widgets/opal/header/org.eclipse.nebula.widgets.opal.header.feature/feature.xml
+++ b/widgets/opal/header/org.eclipse.nebula.widgets.opal.header.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.nebula.widgets.opal.header.feature"
       label="Nebula Opal Header Widget"
-      version="1.0.0.qualifier"
+      version="1.1.0.qualifier"
       provider-name="Eclipse Nebula">
 
    <description url="http://eclipse.org/nebula">

--- a/widgets/opal/header/org.eclipse.nebula.widgets.opal.header.feature/pom.xml
+++ b/widgets/opal/header/org.eclipse.nebula.widgets.opal.header.feature/pom.xml
@@ -24,7 +24,7 @@ Contributors:
 
 	<artifactId>org.eclipse.nebula.widgets.opal.header.feature</artifactId>
 	<packaging>eclipse-feature</packaging>
-	<version>1.0.0-SNAPSHOT</version>
+	<version>1.1.0-SNAPSHOT</version>
 
 	<name>Header Feature</name>
 

--- a/widgets/opal/header/org.eclipse.nebula.widgets.opal.header/META-INF/MANIFEST.MF
+++ b/widgets/opal/header/org.eclipse.nebula.widgets.opal.header/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Nebula Opal Header
 Bundle-SymbolicName: org.eclipse.nebula.widgets.opal.header
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.1.0.qualifier
 Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.nebula.widgets.opal.commons;bundle-version="1.0.0";visibility:=reexport,

--- a/widgets/opal/header/org.eclipse.nebula.widgets.opal.header/META-INF/MANIFEST.MF
+++ b/widgets/opal/header/org.eclipse.nebula.widgets.opal.header/META-INF/MANIFEST.MF
@@ -6,6 +6,6 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.nebula.widgets.opal.commons;bundle-version="1.0.0";visibility:=reexport,
- org.eclipse.swt
+ org.eclipse.swt;bundle-version="[3.115.0,4.0.0)"
 Export-Package: org.eclipse.nebula.widgets.opal.header
 Automatic-Module-Name: org.eclipse.nebula.widgets.opal.header

--- a/widgets/opal/header/org.eclipse.nebula.widgets.opal.header/pom.xml
+++ b/widgets/opal/header/org.eclipse.nebula.widgets.opal.header/pom.xml
@@ -19,6 +19,7 @@ http://www.eclipse.org/legal/epl-v10.html
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.opal.header</artifactId>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/widgets/opal/header/org.eclipse.nebula.widgets.opal.header/src/org/eclipse/nebula/widgets/opal/header/Header.java
+++ b/widgets/opal/header/org.eclipse.nebula.widgets.opal.header/src/org/eclipse/nebula/widgets/opal/header/Header.java
@@ -107,19 +107,19 @@ public class Header extends Composite {
 		titleFont = defaultFont;
 		SWTGraphicUtil.addDisposer(this, defaultFont);
 
-		final Color defaultTitleColor = new Color(getDisplay(), 0, 88, 150);
+		final Color defaultTitleColor = new Color(0, 88, 150);
 		titleColor = defaultTitleColor;
 		SWTGraphicUtil.addDisposer(this, defaultTitleColor);
 
-		final Color defaultGradientEndColor = new Color(getDisplay(), 239, 239, 239);
+		final Color defaultGradientEndColor = new Color(239, 239, 239);
 		gradientEnd = defaultGradientEndColor;
 		SWTGraphicUtil.addDisposer(this, defaultGradientEndColor);
 
-		final Color defaultGradientStartColor = new Color(getDisplay(), 255, 255, 255);
+		final Color defaultGradientStartColor = new Color(255, 255, 255);
 		gradientStart = defaultGradientStartColor;
 		SWTGraphicUtil.addDisposer(this, defaultGradientStartColor);
 
-		final Color defaultSeparatorColor = new Color(getDisplay(), 229, 229, 229);
+		final Color defaultSeparatorColor = new Color(229, 229, 229);
 		separatorColor = defaultSeparatorColor;
 		SWTGraphicUtil.addDisposer(this, defaultSeparatorColor);
 	}

--- a/widgets/opal/logindialog/org.eclipse.nebula.widgets.opal.logindialog.feature/feature.xml
+++ b/widgets/opal/logindialog/org.eclipse.nebula.widgets.opal.logindialog.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.nebula.widgets.opal.logindialog.feature"
       label="Nebula Opal Login Dialog Widget"
-      version="1.0.0.qualifier"
+      version="1.1.0.qualifier"
       provider-name="Eclipse Nebula">
 
    <description url="http://eclipse.org/nebula">

--- a/widgets/opal/logindialog/org.eclipse.nebula.widgets.opal.logindialog.feature/pom.xml
+++ b/widgets/opal/logindialog/org.eclipse.nebula.widgets.opal.logindialog.feature/pom.xml
@@ -26,6 +26,6 @@ Contributors:
 	<packaging>eclipse-feature</packaging>
 
 	<name>PromptSupport Feature</name>
-	<version>1.0.0-SNAPSHOT</version>
+	<version>1.1.0-SNAPSHOT</version>
 
 </project>

--- a/widgets/opal/logindialog/org.eclipse.nebula.widgets.opal.logindialog/META-INF/MANIFEST.MF
+++ b/widgets/opal/logindialog/org.eclipse.nebula.widgets.opal.logindialog/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.nebula.widgets.opal.commons;bundle-version="1.0.0";visibility:=reexport,
  org.eclipse.nebula.widgets.opal.dialog;bundle-version="1.0.0",
- org.eclipse.swt
+ org.eclipse.swt;bundle-version="[3.115.0,4.0.0)"
 Import-Package: org.eclipse.nebula.widgets.opal.dialog
 Export-Package: org.eclipse.nebula.widgets.opal.loginDialog
 Automatic-Module-Name: org.eclipse.nebula.widgets.opal.logindialog

--- a/widgets/opal/logindialog/org.eclipse.nebula.widgets.opal.logindialog/META-INF/MANIFEST.MF
+++ b/widgets/opal/logindialog/org.eclipse.nebula.widgets.opal.logindialog/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Nebula Opal Login Dialog Widget
 Bundle-SymbolicName: org.eclipse.nebula.widgets.opal.logindialog
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.1.0.qualifier
 Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.nebula.widgets.opal.commons;bundle-version="1.0.0";visibility:=reexport,

--- a/widgets/opal/logindialog/org.eclipse.nebula.widgets.opal.logindialog/pom.xml
+++ b/widgets/opal/logindialog/org.eclipse.nebula.widgets.opal.logindialog/pom.xml
@@ -19,6 +19,7 @@ http://www.eclipse.org/legal/epl-v10.html
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.opal.logindialog</artifactId>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/widgets/opal/logindialog/org.eclipse.nebula.widgets.opal.logindialog/src/org/eclipse/nebula/widgets/opal/loginDialog/LoginDialog.java
+++ b/widgets/opal/logindialog/org.eclipse.nebula.widgets.opal.logindialog/src/org/eclipse/nebula/widgets/opal/loginDialog/LoginDialog.java
@@ -141,9 +141,9 @@ public class LoginDialog {
 	 */
 	private Image createDefaultImage(final int w, final int h) {
 		final Display display = Display.getCurrent();
-		final Color backgroundColor = new Color(display, 49, 121, 242);
-		final Color gradientColor1 = new Color(display, 155, 185, 245);
-		final Color gradientColor2 = new Color(display, 53, 123, 242);
+		final Color backgroundColor = new Color(49, 121, 242);
+		final Color gradientColor1 = new Color(155, 185, 245);
+		final Color gradientColor2 = new Color(53, 123, 242);
 
 		final Image img = new Image(display, w, h);
 		final GC gc = new GC(img);

--- a/widgets/opal/notifier/org.eclipse.nebula.widgets.opal.notifier.feature/feature.xml
+++ b/widgets/opal/notifier/org.eclipse.nebula.widgets.opal.notifier.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.nebula.widgets.opal.notifier.feature"
       label="Nebula Opal Notifier Widget"
-      version="1.0.0.qualifier"
+      version="1.1.0.qualifier"
       provider-name="Eclipse Nebula">
 
    <description url="http://eclipse.org/nebula">

--- a/widgets/opal/notifier/org.eclipse.nebula.widgets.opal.notifier.feature/pom.xml
+++ b/widgets/opal/notifier/org.eclipse.nebula.widgets.opal.notifier.feature/pom.xml
@@ -18,7 +18,7 @@
 
 	<artifactId>org.eclipse.nebula.widgets.opal.notifier.feature</artifactId>
 	<packaging>eclipse-feature</packaging>
-	<version>1.0.0-SNAPSHOT</version>
+	<version>1.1.0-SNAPSHOT</version>
 
 	<name>Notifier Feature</name>
 

--- a/widgets/opal/notifier/org.eclipse.nebula.widgets.opal.notifier/META-INF/MANIFEST.MF
+++ b/widgets/opal/notifier/org.eclipse.nebula.widgets.opal.notifier/META-INF/MANIFEST.MF
@@ -6,6 +6,6 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.nebula.widgets.opal.commons;bundle-version="1.0.0";visibility:=reexport,
- org.eclipse.swt
+ org.eclipse.swt;bundle-version="[3.115.0,4.0.0)"
 Export-Package: org.eclipse.nebula.widgets.opal.notifier
 Automatic-Module-Name: org.eclipse.nebula.widgets.opal.notifier

--- a/widgets/opal/notifier/org.eclipse.nebula.widgets.opal.notifier/META-INF/MANIFEST.MF
+++ b/widgets/opal/notifier/org.eclipse.nebula.widgets.opal.notifier/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Nebula Opal Notifier Widget
 Bundle-SymbolicName: org.eclipse.nebula.widgets.opal.notifier
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.1.0.qualifier
 Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.nebula.widgets.opal.commons;bundle-version="1.0.0";visibility:=reexport,

--- a/widgets/opal/notifier/org.eclipse.nebula.widgets.opal.notifier/pom.xml
+++ b/widgets/opal/notifier/org.eclipse.nebula.widgets.opal.notifier/pom.xml
@@ -17,6 +17,7 @@
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.opal.notifier</artifactId>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/widgets/opal/notifier/org.eclipse.nebula.widgets.opal.notifier/src/org/eclipse/nebula/widgets/opal/notifier/NotifierColorsFactory.java
+++ b/widgets/opal/notifier/org.eclipse.nebula.widgets.opal.notifier/src/org/eclipse/nebula/widgets/opal/notifier/NotifierColorsFactory.java
@@ -42,25 +42,25 @@ public class NotifierColorsFactory {
 		Display display = Display.getDefault();
 		switch (theme) {
 		case BLUE_THEME:
-			colors.textColor = new Color(display, 4, 64, 140);
-			colors.titleColor = new Color(display, 0, 0, 0);
-			colors.borderColor = new Color(display, 153, 188, 232);
-			colors.leftColor = new Color(display, 210, 225, 244);
-			colors.rightColor = new Color(display, 182, 207, 238);
+			colors.textColor = new Color(4, 64, 140);
+			colors.titleColor = new Color(0, 0, 0);
+			colors.borderColor = new Color(153, 188, 232);
+			colors.leftColor = new Color(210, 225, 244);
+			colors.rightColor = new Color(182, 207, 238);
 			break;
 		case GRAY_THEME:
-			colors.textColor = new Color(display, 0, 0, 0);
-			colors.titleColor = new Color(display, 255, 20, 20);
-			colors.borderColor = new Color(display, 208, 208, 208);
-			colors.leftColor = new Color(display, 255, 255, 255);
-			colors.rightColor = new Color(display, 208, 208, 208);
+			colors.textColor = new Color(0, 0, 0);
+			colors.titleColor = new Color(255, 20, 20);
+			colors.borderColor = new Color(208, 208, 208);
+			colors.leftColor = new Color(255, 255, 255);
+			colors.rightColor = new Color(208, 208, 208);
 			break;
 		default:
-			colors.textColor = new Color(display, 0, 0, 0);
-			colors.titleColor = new Color(display, 0, 0, 0);
-			colors.borderColor = new Color(display, 218, 178, 85);
-			colors.leftColor = new Color(display, 220, 220, 160);
-			colors.rightColor = new Color(display, 255, 255, 191);
+			colors.textColor = new Color(0, 0, 0);
+			colors.titleColor = new Color(0, 0, 0);
+			colors.borderColor = new Color(218, 178, 85);
+			colors.leftColor = new Color(220, 220, 160);
+			colors.rightColor = new Color(255, 255, 191);
 			break;
 		}
 		return colors;

--- a/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow.feature/feature.xml
+++ b/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.nebula.widgets.opal.preferencewindow.feature"
       label="Nebula Opal Preference Window Widget"
-      version="1.0.0.qualifier"
+      version="1.1.0.qualifier"
       provider-name="Eclipse Nebula">
 
    <description url="http://eclipse.org/nebula">

--- a/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow.feature/pom.xml
+++ b/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow.feature/pom.xml
@@ -24,7 +24,7 @@ Contributors:
 
 	<artifactId>org.eclipse.nebula.widgets.opal.preferencewindow.feature</artifactId>
 	<packaging>eclipse-feature</packaging>
-	<version>1.0.0-SNAPSHOT</version>
+	<version>1.1.0-SNAPSHOT</version>
 
 	<name>Preference Window Feature</name>
 

--- a/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/META-INF/MANIFEST.MF
+++ b/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Nebula Opal Preference Window Widget
 Bundle-SymbolicName: org.eclipse.nebula.widgets.opal.preferencewindow
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.1.0.qualifier
 Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.nebula.widgets.opal.commons;bundle-version="1.0.0";visibility:=reexport,

--- a/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/META-INF/MANIFEST.MF
+++ b/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.nebula.widgets.opal.commons;bundle-version="1.0.0";visibility:=reexport,
  org.eclipse.nebula.widgets.opal.titledseparator;bundle-version="1.0.0",
  org.eclipse.nebula.widgets.opal.dialog;bundle-version="1.0.0";visibility:=reexport,
- org.eclipse.swt
+ org.eclipse.swt;bundle-version="[3.115.0,4.0.0)"
 Export-Package: org.eclipse.nebula.widgets.opal.preferencewindow,
  org.eclipse.nebula.widgets.opal.preferencewindow.enabler,
  org.eclipse.nebula.widgets.opal.preferencewindow.widgets

--- a/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/pom.xml
+++ b/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/pom.xml
@@ -19,6 +19,7 @@ http://www.eclipse.org/legal/epl-v10.html
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.opal.preferencewindow</artifactId>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/src/org/eclipse/nebula/widgets/opal/preferencewindow/FlatButton.java
+++ b/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/src/org/eclipse/nebula/widgets/opal/preferencewindow/FlatButton.java
@@ -141,9 +141,9 @@ class FlatButton extends Canvas {
 
 	private void initializeDefaultColors() {
 		backgroundColor = getDisplay().getSystemColor(SWT.COLOR_WHITE);
-		selectedColor = new Color(getDisplay(), 0, 112, 192);
+		selectedColor = new Color(0, 112, 192);
 		selectedTextColor = getDisplay().getSystemColor(SWT.COLOR_WHITE);
-		mouseOverColor = new Color(getDisplay(), 235, 234, 226);
+		mouseOverColor = new Color(235, 234, 226);
 
 		SWTGraphicUtil.addDisposer(this, selectedColor);
 		SWTGraphicUtil.addDisposer(this, mouseOverColor);

--- a/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/src/org/eclipse/nebula/widgets/opal/preferencewindow/PWTabContainer.java
+++ b/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/src/org/eclipse/nebula/widgets/opal/preferencewindow/PWTabContainer.java
@@ -56,7 +56,7 @@ class PWTabContainer extends Composite {
 		gridLayout.horizontalSpacing = gridLayout.verticalSpacing = 0;
 		setLayout(gridLayout);
 
-		grey = new Color(getDisplay(), 204, 204, 204);
+		grey = new Color(204, 204, 204);
 		SWTGraphicUtil.addDisposer(this, grey);
 	}
 

--- a/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/src/org/eclipse/nebula/widgets/opal/preferencewindow/widgets/PWColorChooser.java
+++ b/widgets/opal/preferencewindow/org.eclipse.nebula.widgets.opal.preferencewindow/src/org/eclipse/nebula/widgets/opal/preferencewindow/widgets/PWColorChooser.java
@@ -53,7 +53,7 @@ public class PWColorChooser extends PWWidget {
 		if (rgb == null) {
 			color = Display.getDefault().getSystemColor(SWT.COLOR_WHITE);
 		} else {
-			color = new Color(Display.getDefault(), rgb);
+			color = new Color(rgb);
 		}
 
 		buildLabel(parent, GridData.CENTER);
@@ -72,7 +72,7 @@ public class PWColorChooser extends PWWidget {
 			final RGB result = dialog.open();
 			if (result != null) {
 				SWTGraphicUtil.safeDispose(color);
-				color = new Color(button.getDisplay(), result);
+				color = new Color(result);
 				drawButton(button);
 				PreferenceWindow.getInstance().setValue(getPropertyKey(), result);
 			}

--- a/widgets/opal/propertytable/org.eclipse.nebula.widgets.opal.propertytable.feature/feature.xml
+++ b/widgets/opal/propertytable/org.eclipse.nebula.widgets.opal.propertytable.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.nebula.widgets.opal.propertytable.feature"
       label="Nebula Property Table Widget"
-      version="1.0.2.qualifier"
+      version="1.1.0.qualifier"
       provider-name="Eclipse Nebula">
 
    <description url="http://eclipse.org/nebula">

--- a/widgets/opal/propertytable/org.eclipse.nebula.widgets.opal.propertytable.feature/pom.xml
+++ b/widgets/opal/propertytable/org.eclipse.nebula.widgets.opal.propertytable.feature/pom.xml
@@ -24,7 +24,7 @@ Contributors:
 
 	<artifactId>org.eclipse.nebula.widgets.opal.propertytable.feature</artifactId>
 	<packaging>eclipse-feature</packaging>
-	<version>1.0.2-SNAPSHOT</version>
+	<version>1.1.0-SNAPSHOT</version>
 
 	<name>Property Table Feature</name>
 

--- a/widgets/opal/propertytable/org.eclipse.nebula.widgets.opal.propertytable/META-INF/MANIFEST.MF
+++ b/widgets/opal/propertytable/org.eclipse.nebula.widgets.opal.propertytable/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.nebula.widgets.opal.commons;bundle-version="1.0.0";visibility:=reexport,
  org.eclipse.nebula.widgets.opal.dialog;bundle-version="1.0.0",
- org.eclipse.swt
+ org.eclipse.swt;bundle-version="[3.115.0,4.0.0)"
 Export-Package: org.eclipse.nebula.widgets.opal.propertytable,
  org.eclipse.nebula.widgets.opal.propertytable.editor
 Automatic-Module-Name: org.eclipse.nebula.widgets.opal.propertytable

--- a/widgets/opal/propertytable/org.eclipse.nebula.widgets.opal.propertytable/META-INF/MANIFEST.MF
+++ b/widgets/opal/propertytable/org.eclipse.nebula.widgets.opal.propertytable/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Nebula Open Property Table Widget
 Bundle-SymbolicName: org.eclipse.nebula.widgets.opal.propertytable
-Bundle-Version: 1.0.2.qualifier
+Bundle-Version: 1.1.0.qualifier
 Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.nebula.widgets.opal.commons;bundle-version="1.0.0";visibility:=reexport,

--- a/widgets/opal/propertytable/org.eclipse.nebula.widgets.opal.propertytable/pom.xml
+++ b/widgets/opal/propertytable/org.eclipse.nebula.widgets.opal.propertytable/pom.xml
@@ -18,6 +18,7 @@ http://www.eclipse.org/legal/epl-v10.html
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.opal.propertytable</artifactId>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 	
 </project>

--- a/widgets/opal/propertytable/org.eclipse.nebula.widgets.opal.propertytable/src/org/eclipse/nebula/widgets/opal/propertytable/editor/PTColorEditor.java
+++ b/widgets/opal/propertytable/org.eclipse.nebula.widgets.opal.propertytable/src/org/eclipse/nebula/widgets/opal/propertytable/editor/PTColorEditor.java
@@ -85,7 +85,7 @@ public class PTColorEditor extends PTChooserEditor {
 			return null;
 		}
 		final RGB rgb = (RGB) property.getValue();
-		return new Color(Display.getDefault(), rgb);
+		return new Color(rgb);
 	}
 
 }

--- a/widgets/opal/titledseparator/org.eclipse.nebula.widgets.opal.titledseparator.feature/feature.xml
+++ b/widgets/opal/titledseparator/org.eclipse.nebula.widgets.opal.titledseparator.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.nebula.widgets.opal.titledseparator.feature"
       label="Nebula Opal Titled Separator Widget"
-      version="1.0.0.qualifier"
+      version="1.1.0.qualifier"
       provider-name="Eclipse Nebula">
 
    <description url="http://eclipse.org/nebula">

--- a/widgets/opal/titledseparator/org.eclipse.nebula.widgets.opal.titledseparator.feature/pom.xml
+++ b/widgets/opal/titledseparator/org.eclipse.nebula.widgets.opal.titledseparator.feature/pom.xml
@@ -24,7 +24,7 @@ Contributors:
 
 	<artifactId>org.eclipse.nebula.widgets.opal.titledseparator.feature</artifactId>
 	<packaging>eclipse-feature</packaging>
-	<version>1.0.0-SNAPSHOT</version>
+	<version>1.1.0-SNAPSHOT</version>
 
 	<name>TitledSeparator Feature</name>
 

--- a/widgets/opal/titledseparator/org.eclipse.nebula.widgets.opal.titledseparator/META-INF/MANIFEST.MF
+++ b/widgets/opal/titledseparator/org.eclipse.nebula.widgets.opal.titledseparator/META-INF/MANIFEST.MF
@@ -6,6 +6,6 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.nebula.widgets.opal.commons;bundle-version="1.0.0";visibility:=reexport,
- org.eclipse.swt
+ org.eclipse.swt;bundle-version="[3.115.0,4.0.0)"
 Export-Package: org.eclipse.nebula.widgets.opal.titledseparator
 Automatic-Module-Name: org.eclipse.nebula.widgets.titledseparator

--- a/widgets/opal/titledseparator/org.eclipse.nebula.widgets.opal.titledseparator/META-INF/MANIFEST.MF
+++ b/widgets/opal/titledseparator/org.eclipse.nebula.widgets.opal.titledseparator/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Nebula Opal Titled Separator Widget
 Bundle-SymbolicName: org.eclipse.nebula.widgets.opal.titledseparator
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.1.0.qualifier
 Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.nebula.widgets.opal.commons;bundle-version="1.0.0";visibility:=reexport,

--- a/widgets/opal/titledseparator/org.eclipse.nebula.widgets.opal.titledseparator/pom.xml
+++ b/widgets/opal/titledseparator/org.eclipse.nebula.widgets.opal.titledseparator/pom.xml
@@ -19,6 +19,7 @@ http://www.eclipse.org/legal/epl-v10.html
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.opal.titledseparator</artifactId>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/widgets/opal/titledseparator/org.eclipse.nebula.widgets.opal.titledseparator/src/org/eclipse/nebula/widgets/opal/titledseparator/TitledSeparator.java
+++ b/widgets/opal/titledseparator/org.eclipse.nebula.widgets.opal.titledseparator/src/org/eclipse/nebula/widgets/opal/titledseparator/TitledSeparator.java
@@ -74,7 +74,7 @@ public class TitledSeparator extends Composite {
 		super(parent, style);
 		alignment = SWT.LEFT;
 
-		final Color originalColor = new Color(getDisplay(), 0, 88, 150);
+		final Color originalColor = new Color(0, 88, 150);
 		setForeground(originalColor);
 
 		final Font originalFont;

--- a/widgets/oscilloscope/org.eclipse.nebula.widgets.oscilloscope.feature/feature.xml
+++ b/widgets/oscilloscope/org.eclipse.nebula.widgets.oscilloscope.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.nebula.widgets.oscilloscope.feature"
       label="%featureName"
-      version="1.4.0.qualifier"
+      version="1.5.0.qualifier"
       provider-name="%provider">
 
    <description url="%featureDescriptionURL">

--- a/widgets/oscilloscope/org.eclipse.nebula.widgets.oscilloscope.feature/pom.xml
+++ b/widgets/oscilloscope/org.eclipse.nebula.widgets.oscilloscope.feature/pom.xml
@@ -23,6 +23,7 @@ Contributors:
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.oscilloscope.feature</artifactId>
+	<version>1.5.0-SNAPSHOT</version>
 	<packaging>eclipse-feature</packaging>
 
 	<name>Nebula Oscilloscope Widget</name>

--- a/widgets/oscilloscope/org.eclipse.nebula.widgets.oscilloscope/META-INF/MANIFEST.MF
+++ b/widgets/oscilloscope/org.eclipse.nebula.widgets.oscilloscope/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Nebula Oscilloscope
 Bundle-SymbolicName: org.eclipse.nebula.widgets.oscilloscope
-Bundle-Version: 1.4.0.qualifier
+Bundle-Version: 1.5.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.swt;bundle-version="[3.115.0,4.0.0)"
 Export-Package: org.eclipse.nebula.widgets.oscilloscope;x-internal:=true,

--- a/widgets/oscilloscope/org.eclipse.nebula.widgets.oscilloscope/META-INF/MANIFEST.MF
+++ b/widgets/oscilloscope/org.eclipse.nebula.widgets.oscilloscope/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Nebula Oscilloscope
 Bundle-SymbolicName: org.eclipse.nebula.widgets.oscilloscope
 Bundle-Version: 1.4.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
-Require-Bundle: org.eclipse.swt;bundle-version="3.5.1"
+Require-Bundle: org.eclipse.swt;bundle-version="[3.115.0,4.0.0)"
 Export-Package: org.eclipse.nebula.widgets.oscilloscope;x-internal:=true,
  org.eclipse.nebula.widgets.oscilloscope.multichannel
 Bundle-Vendor: Eclipse Nebula

--- a/widgets/oscilloscope/org.eclipse.nebula.widgets.oscilloscope/pom.xml
+++ b/widgets/oscilloscope/org.eclipse.nebula.widgets.oscilloscope/pom.xml
@@ -25,6 +25,7 @@ Contributors:
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.oscilloscope</artifactId>
+	<version>1.5.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/widgets/oscilloscope/org.eclipse.nebula.widgets.oscilloscope/src/org/eclipse/nebula/widgets/oscilloscope/multichannel/Oscilloscope.java
+++ b/widgets/oscilloscope/org.eclipse.nebula.widgets.oscilloscope/src/org/eclipse/nebula/widgets/oscilloscope/multichannel/Oscilloscope.java
@@ -411,9 +411,9 @@ public class Oscilloscope extends Canvas {
 
 		gridSquareSize = 20;
 		gridLineWidth = 1;
-		final Color defaultGridBackground = new Color(getDisplay(), 57, 52, 56);
+		final Color defaultGridBackground = new Color(57, 52, 56);
 		gridBackground = defaultGridBackground;
-		final Color defaultGridForeground = new Color(getDisplay(), 81, 96, 77);
+		final Color defaultGridForeground = new Color(81, 96, 77);
 		gridForeground = defaultGridForeground;
 		addListener(SWT.Dispose, e-> {
 			defaultGridBackground.dispose();

--- a/widgets/paperclips/org.eclipse.nebula.paperclips.core/META-INF/MANIFEST.MF
+++ b/widgets/paperclips/org.eclipse.nebula.paperclips.core/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Nebula Paperclips Core
 Bundle-SymbolicName: org.eclipse.nebula.paperclips.core
 Bundle-Version: 2.1.0.qualifier
 Bundle-Vendor: Eclipse Nebula
-Require-Bundle: org.eclipse.swt;bundle-version="[3.2.0,4.0.0)"
+Require-Bundle: org.eclipse.swt;bundle-version="[3.115.0,4.0.0)"
 Export-Package: org.eclipse.nebula.paperclips.core,
  org.eclipse.nebula.paperclips.core.border,
  org.eclipse.nebula.paperclips.core.border.internal,

--- a/widgets/paperclips/org.eclipse.nebula.paperclips.core/META-INF/MANIFEST.MF
+++ b/widgets/paperclips/org.eclipse.nebula.paperclips.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Nebula Paperclips Core
 Bundle-SymbolicName: org.eclipse.nebula.paperclips.core
-Bundle-Version: 2.1.0.qualifier
+Bundle-Version: 2.2.0.qualifier
 Bundle-Vendor: Eclipse Nebula
 Require-Bundle: org.eclipse.swt;bundle-version="[3.115.0,4.0.0)"
 Export-Package: org.eclipse.nebula.paperclips.core,

--- a/widgets/paperclips/org.eclipse.nebula.paperclips.core/pom.xml
+++ b/widgets/paperclips/org.eclipse.nebula.paperclips.core/pom.xml
@@ -23,6 +23,7 @@ Contributors:
 	</parent>
 
 	<artifactId>org.eclipse.nebula.paperclips.core</artifactId>
+	<version>2.2.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/widgets/paperclips/org.eclipse.nebula.paperclips.core/src/org/eclipse/nebula/paperclips/core/internal/util/ResourcePool.java
+++ b/widgets/paperclips/org.eclipse.nebula.paperclips.core/src/org/eclipse/nebula/paperclips/core/internal/util/ResourcePool.java
@@ -102,7 +102,7 @@ public class ResourcePool {
 
 		Color color = colors.get(rgb);
 		if (color == null) {
-			color = new Color(device, rgb);
+			color = new Color(rgb);
 			colors.put(SWTUtil.copy(rgb), color);
 		}
 		return color;

--- a/widgets/paperclips/org.eclipse.nebula.widgets.paperclips.feature/feature.xml
+++ b/widgets/paperclips/org.eclipse.nebula.widgets.paperclips.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.nebula.widgets.paperclips.feature"
       label="%featureName"
-      version="2.1.0.qualifier"
+      version="2.2.0.qualifier"
       provider-name="%providerName">
 
    <description>

--- a/widgets/paperclips/org.eclipse.nebula.widgets.paperclips.feature/pom.xml
+++ b/widgets/paperclips/org.eclipse.nebula.widgets.paperclips.feature/pom.xml
@@ -23,6 +23,7 @@ Contributors:
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.paperclips.feature</artifactId>
+	<version>2.2.0-SNAPSHOT</version>
 	<packaging>eclipse-feature</packaging>
 
 	<name>Nebula Examples View Feature</name>

--- a/widgets/passwordrevealer/org.eclipse.nebula.widgets.passwordrevealer.feature/feature.xml
+++ b/widgets/passwordrevealer/org.eclipse.nebula.widgets.passwordrevealer.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.nebula.widgets.passwordrevealer.feature"
       label="Nebula Password Revealer Widget"
-      version="1.0.0.qualifier"
+      version="1.1.0.qualifier"
       provider-name="Eclipse Nebula">
 
    <description url="http://eclipse.org/nebula">

--- a/widgets/passwordrevealer/org.eclipse.nebula.widgets.passwordrevealer.feature/pom.xml
+++ b/widgets/passwordrevealer/org.eclipse.nebula.widgets.passwordrevealer.feature/pom.xml
@@ -24,7 +24,7 @@ Contributors:
 
 	<artifactId>org.eclipse.nebula.widgets.passwordrevealer.feature</artifactId>
 	<packaging>eclipse-feature</packaging>
-	<version>1.0.0-SNAPSHOT</version>
+	<version>1.1.0-SNAPSHOT</version>
 
 	<name>Password Revealer Feature</name>
 

--- a/widgets/passwordrevealer/org.eclipse.nebula.widgets.passwordrevealer/META-INF/MANIFEST.MF
+++ b/widgets/passwordrevealer/org.eclipse.nebula.widgets.passwordrevealer/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Nebula Password Revealer Widget
 Bundle-SymbolicName: org.eclipse.nebula.widgets.passwordrevealer
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.1.0.qualifier
 Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.eclipse.nebula.widgets.passwordrevealer

--- a/widgets/passwordrevealer/org.eclipse.nebula.widgets.passwordrevealer/META-INF/MANIFEST.MF
+++ b/widgets/passwordrevealer/org.eclipse.nebula.widgets.passwordrevealer/META-INF/MANIFEST.MF
@@ -7,5 +7,5 @@ Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.eclipse.nebula.widgets.passwordrevealer
 Require-Bundle: org.eclipse.nebula.widgets.opal.commons;bundle-version="1.0.0";visibility:=reexport,
- org.eclipse.swt
+ org.eclipse.swt;bundle-version="[3.115.0,4.0.0)"
 Automatic-Module-Name: org.eclipse.nebula.widgets.passwordrevealer

--- a/widgets/passwordrevealer/org.eclipse.nebula.widgets.passwordrevealer/pom.xml
+++ b/widgets/passwordrevealer/org.eclipse.nebula.widgets.passwordrevealer/pom.xml
@@ -19,6 +19,7 @@ http://www.eclipse.org/legal/epl-v10.html
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.passwordrevealer</artifactId>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/widgets/passwordrevealer/org.eclipse.nebula.widgets.passwordrevealer/src/org/eclipse/nebula/widgets/passwordrevealer/EyeButton.java
+++ b/widgets/passwordrevealer/org.eclipse.nebula.widgets.passwordrevealer/src/org/eclipse/nebula/widgets/passwordrevealer/EyeButton.java
@@ -36,7 +36,7 @@ class EyeButton extends Canvas {
 		super(parent, SWT.DOUBLE_BUFFERED);
 		isPushMode = (style & SWT.PUSH) == SWT.PUSH;
 		addListeners();
-		color = new Color(parent.getDisplay(), 0, 127, 222);
+		color = new Color(0, 127, 222);
 		SWTGraphicUtil.addDisposer(this, color);
 		setBackground(getDisplay().getSystemColor(SWT.COLOR_WHITE));
 		pushState = false;

--- a/widgets/progresscircle/org.eclipse.nebula.widgets.progresscircle.feature/feature.xml
+++ b/widgets/progresscircle/org.eclipse.nebula.widgets.progresscircle.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.nebula.widgets.progresscircle.feature"
       label="Nebula Progress Circle Widget"
-      version="1.0.0.qualifier"
+      version="1.1.0.qualifier"
       provider-name="Eclipse Nebula">
 
    <description url="http://eclipse.org/nebula">

--- a/widgets/progresscircle/org.eclipse.nebula.widgets.progresscircle.feature/pom.xml
+++ b/widgets/progresscircle/org.eclipse.nebula.widgets.progresscircle.feature/pom.xml
@@ -25,7 +25,7 @@ Contributors:
 
 	<artifactId>org.eclipse.nebula.widgets.progresscircle.feature</artifactId>
 	<packaging>eclipse-feature</packaging>
-	<version>1.0.0-SNAPSHOT</version>
+	<version>1.1.0-SNAPSHOT</version>
 
 	<name>Progress Circle Feature</name>
 

--- a/widgets/progresscircle/org.eclipse.nebula.widgets.progresscircle.snippets/META-INF/MANIFEST.MF
+++ b/widgets/progresscircle/org.eclipse.nebula.widgets.progresscircle.snippets/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Nebula Progress Circle Snippets
 Bundle-SymbolicName: org.eclipse.nebula.widgets.progresscircle.snippets
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.1.0.qualifier
 Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.nebula.widgets.progresscircle;bundle-version="1.0.0",

--- a/widgets/progresscircle/org.eclipse.nebula.widgets.progresscircle.snippets/META-INF/MANIFEST.MF
+++ b/widgets/progresscircle/org.eclipse.nebula.widgets.progresscircle.snippets/META-INF/MANIFEST.MF
@@ -6,5 +6,5 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.nebula.widgets.progresscircle;bundle-version="1.0.0",
- org.eclipse.swt
+ org.eclipse.swt;bundle-version="[3.115.0,4.0.0)"
 Automatic-Module-Name: org.eclipse.nebula.widgets.progresscircle.snippets

--- a/widgets/progresscircle/org.eclipse.nebula.widgets.progresscircle.snippets/pom.xml
+++ b/widgets/progresscircle/org.eclipse.nebula.widgets.progresscircle.snippets/pom.xml
@@ -19,6 +19,7 @@ http://www.eclipse.org/legal/epl-v10.html
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.progresscircle.snippets</artifactId>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/widgets/progresscircle/org.eclipse.nebula.widgets.progresscircle.snippets/src/org/eclipse/nebula/widgets/progresscircle/snippets/AbsolutePanel.java
+++ b/widgets/progresscircle/org.eclipse.nebula.widgets.progresscircle.snippets/src/org/eclipse/nebula/widgets/progresscircle/snippets/AbsolutePanel.java
@@ -63,7 +63,7 @@ class AbsolutePanel extends BasePanel {
 		circle.setCircleSize(100);
 		circle.setShowText(true);
 
-		final Color green = new Color(shell.getDisplay(), 113, 178, 123);
+		final Color green = new Color(113, 178, 123);
 		shell.addDisposeListener((e) -> green.dispose());
 		circle.setHighlightColor(green);
 

--- a/widgets/progresscircle/org.eclipse.nebula.widgets.progresscircle.snippets/src/org/eclipse/nebula/widgets/progresscircle/snippets/TimePanel.java
+++ b/widgets/progresscircle/org.eclipse.nebula.widgets.progresscircle.snippets/src/org/eclipse/nebula/widgets/progresscircle/snippets/TimePanel.java
@@ -91,7 +91,7 @@ class TimePanel extends BasePanel {
 		circle.setCircleSize(100);
 		circle.setShowText(true);
 
-		final Color red = new Color(shell.getDisplay(), 222, 80, 79);
+		final Color red = new Color(222, 80, 79);
 		shell.addDisposeListener((e) -> red.dispose());
 		circle.setHighlightColor(red);
 

--- a/widgets/progresscircle/org.eclipse.nebula.widgets.progresscircle/META-INF/MANIFEST.MF
+++ b/widgets/progresscircle/org.eclipse.nebula.widgets.progresscircle/META-INF/MANIFEST.MF
@@ -7,5 +7,5 @@ Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.eclipse.nebula.widgets.progresscircle
 Require-Bundle: org.eclipse.nebula.widgets.opal.commons;bundle-version="1.0.0";visibility:=reexport,
- org.eclipse.swt
+ org.eclipse.swt;bundle-version="[3.115.0,4.0.0)"
 Automatic-Module-Name: org.eclipse.nebula.widgets.progresscircle

--- a/widgets/progresscircle/org.eclipse.nebula.widgets.progresscircle/META-INF/MANIFEST.MF
+++ b/widgets/progresscircle/org.eclipse.nebula.widgets.progresscircle/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Nebula Progress Circle Widget
 Bundle-SymbolicName: org.eclipse.nebula.widgets.progresscircle
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.1.0.qualifier
 Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.eclipse.nebula.widgets.progresscircle

--- a/widgets/progresscircle/org.eclipse.nebula.widgets.progresscircle/pom.xml
+++ b/widgets/progresscircle/org.eclipse.nebula.widgets.progresscircle/pom.xml
@@ -19,6 +19,7 @@ http://www.eclipse.org/legal/epl-v10.html
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.progresscircle</artifactId>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/widgets/progresscircle/org.eclipse.nebula.widgets.progresscircle/src/org/eclipse/nebula/widgets/progresscircle/ProgressCircle.java
+++ b/widgets/progresscircle/org.eclipse.nebula.widgets.progresscircle/src/org/eclipse/nebula/widgets/progresscircle/ProgressCircle.java
@@ -111,7 +111,7 @@ public class ProgressCircle extends Canvas {
 	}
 
 	private Color getAndDisposeColor(int r, int g, int b) {
-		final Color color = new Color(getDisplay(), r, g, b);
+		final Color color = new Color(r, g, b);
 		addDisposeListener(e -> {
 			if (!color.isDisposed()) {
 				color.dispose();

--- a/widgets/pshelf/org.eclipse.nebula.widgets.pshelf.css.feature/feature.xml
+++ b/widgets/pshelf/org.eclipse.nebula.widgets.pshelf.css.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.nebula.widgets.pshelf.css.feature"
       label="Nebula PShelf CSS"
-      version="1.0.0.qualifier"
+      version="1.1.0.qualifier"
       provider-name="Eclipse Nebula">
 
    <description url="http://eclipse.org/nebula">

--- a/widgets/pshelf/org.eclipse.nebula.widgets.pshelf.css.feature/pom.xml
+++ b/widgets/pshelf/org.eclipse.nebula.widgets.pshelf.css.feature/pom.xml
@@ -23,6 +23,7 @@ Contributors:
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.pshelf.css.feature</artifactId>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>eclipse-feature</packaging>
 
 	<name>Nebula PShelf CSS Feature</name>

--- a/widgets/pshelf/org.eclipse.nebula.widgets.pshelf.css/META-INF/MANIFEST.MF
+++ b/widgets/pshelf/org.eclipse.nebula.widgets.pshelf.css/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.eclipse.nebula.widgets.pshelf.css;singleton:=true
 Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
-Require-Bundle: org.eclipse.swt;bundle-version="3.8.0",
+Require-Bundle: org.eclipse.swt;bundle-version="[3.115.0,4.0.0)",
  org.eclipse.nebula.widgets.pshelf;bundle-version="1.0.0",
  org.eclipse.e4.ui.services;bundle-version="0.10.0",
  org.eclipse.e4.ui.css.core;bundle-version="0.10.0",

--- a/widgets/pshelf/org.eclipse.nebula.widgets.pshelf.css/META-INF/MANIFEST.MF
+++ b/widgets/pshelf/org.eclipse.nebula.widgets.pshelf.css/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Nebula PShelf CSS
 Bundle-SymbolicName: org.eclipse.nebula.widgets.pshelf.css;singleton:=true
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.1.0.qualifier
 Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.swt;bundle-version="[3.115.0,4.0.0)",

--- a/widgets/pshelf/org.eclipse.nebula.widgets.pshelf.css/pom.xml
+++ b/widgets/pshelf/org.eclipse.nebula.widgets.pshelf.css/pom.xml
@@ -23,6 +23,7 @@ Contributors:
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.pshelf.css</artifactId>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/widgets/pshelf/org.eclipse.nebula.widgets.pshelf.css/src/org/eclipse/nebula/widgets/pshelf/css/CSSShelfRenderer.java
+++ b/widgets/pshelf/org.eclipse.nebula.widgets.pshelf.css/src/org/eclipse/nebula/widgets/pshelf/css/CSSShelfRenderer.java
@@ -502,13 +502,13 @@ public class CSSShelfRenderer extends AbstractRenderer {
 	}
 
 	private static Color createNewBlendedColor(Color c1, Color c2, int ratio) {
-		Color newColor = new Color(Display.getCurrent(), blend(c1.getRGB(), c2.getRGB(), ratio));
+		Color newColor = new Color(blend(c1.getRGB(), c2.getRGB(), ratio));
 
 		return newColor;
 	}
 
 	private static Color createNewReverseColor(Color c) {
-		Color newColor = new Color(Display.getCurrent(), 255 - c.getRed(), 255 - c.getGreen(), 255 - c.getBlue());
+		Color newColor = new Color(255 - c.getRed(), 255 - c.getGreen(), 255 - c.getBlue());
 		return newColor;
 	}
 
@@ -538,6 +538,6 @@ public class CSSShelfRenderer extends AbstractRenderer {
 
 	private static Color createNewSaturatedColor(Color c, float saturation) {
 		RGB newRGB = saturate(c.getRGB(), saturation);
-		return new Color(Display.getCurrent(), newRGB);
+		return new Color(newRGB);
 	}
 }

--- a/widgets/pshelf/org.eclipse.nebula.widgets.pshelf.css/src/org/eclipse/nebula/widgets/pshelf/css/internal/CSSEngineHelper.java
+++ b/widgets/pshelf/org.eclipse.nebula.widgets.pshelf.css/src/org/eclipse/nebula/widgets/pshelf/css/internal/CSSEngineHelper.java
@@ -147,12 +147,12 @@ public class CSSEngineHelper {
 					Integer.parseInt(rgbValue.getRed().getCssText()), 
 					Integer.parseInt(rgbValue.getGreen().getCssText()),
 					Integer.parseInt(rgbValue.getBlue().getCssText()));
-			return new Color(control.getDisplay(), rgb);
+			return new Color(rgb);
 		} else if( value != null ) {
 			try {
 				Color c = (Color) cssEngine.convert(value, Color.class, control.getDisplay());
 				// Create a copy because we are disposing this colors!!!
-				return new Color(control.getDisplay(),c.getRed(),c.getGreen(),c.getBlue());
+				return new Color(c.getRed(),c.getGreen(),c.getBlue());
 			} catch (Exception e) {
 			}
 		}

--- a/widgets/pshelf/org.eclipse.nebula.widgets.pshelf.feature/feature.xml
+++ b/widgets/pshelf/org.eclipse.nebula.widgets.pshelf.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.nebula.widgets.pshelf.feature"
       label="Nebula PShelf Widget"
-      version="1.0.0.qualifier"
+      version="1.1.0.qualifier"
       provider-name="Eclipse Nebula">
 
    <description url="http://eclipse.org">

--- a/widgets/pshelf/org.eclipse.nebula.widgets.pshelf.feature/pom.xml
+++ b/widgets/pshelf/org.eclipse.nebula.widgets.pshelf.feature/pom.xml
@@ -23,6 +23,7 @@ Contributors:
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.pshelf.feature</artifactId>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>eclipse-feature</packaging>
 
 	<name>Nebula PShelf Feature</name>

--- a/widgets/pshelf/org.eclipse.nebula.widgets.pshelf/META-INF/MANIFEST.MF
+++ b/widgets/pshelf/org.eclipse.nebula.widgets.pshelf/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Nebula PShelf
 Bundle-SymbolicName: org.eclipse.nebula.widgets.pshelf
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.2.0.qualifier
 Bundle-Vendor: Eclipse Nebula
 Require-Bundle: org.eclipse.swt;bundle-version="[3.126.0,4.0.0)",
  org.eclipse.jface,

--- a/widgets/pshelf/org.eclipse.nebula.widgets.pshelf/pom.xml
+++ b/widgets/pshelf/org.eclipse.nebula.widgets.pshelf/pom.xml
@@ -23,7 +23,7 @@ Contributors:
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.pshelf</artifactId>
-	<version>1.1.0-SNAPSHOT</version>
+	<version>1.2.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/widgets/pshelf/org.eclipse.nebula.widgets.pshelf/src/org/eclipse/nebula/widgets/pshelf/RedmondShelfRenderer.java
+++ b/widgets/pshelf/org.eclipse.nebula.widgets.pshelf/src/org/eclipse/nebula/widgets/pshelf/RedmondShelfRenderer.java
@@ -445,13 +445,13 @@ public class RedmondShelfRenderer extends AbstractRenderer {
 	}
 
 	private static Color createNewBlendedColor(Color c1, Color c2, int ratio) {
-		Color newColor = new Color(Display.getCurrent(), blend(c1.getRGB(), c2.getRGB(), ratio));
+		Color newColor = new Color(blend(c1.getRGB(), c2.getRGB(), ratio));
 
 		return newColor;
 	}
 
 	private static Color createNewReverseColor(Color c) {
-		Color newColor = new Color(Display.getCurrent(), 255 - c.getRed(), 255 - c.getGreen(), 255 - c.getBlue());
+		Color newColor = new Color(255 - c.getRed(), 255 - c.getGreen(), 255 - c.getBlue());
 		return newColor;
 	}
 
@@ -481,7 +481,7 @@ public class RedmondShelfRenderer extends AbstractRenderer {
 
 	private static Color createNewSaturatedColor(Color c, float saturation) {
 		RGB newRGB = saturate(c.getRGB(), saturation);
-		return new Color(Display.getCurrent(), newRGB);
+		return new Color(newRGB);
 	}
 
 }

--- a/widgets/roundedcheckbox/org.eclipse.nebula.widgets.roundedcheckbox.feature/feature.xml
+++ b/widgets/roundedcheckbox/org.eclipse.nebula.widgets.roundedcheckbox.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.nebula.widgets.roundedcheckbox.feature"
       label="Nebula Rounded Checkbox Widget"
-      version="1.0.0.qualifier"
+      version="1.1.0.qualifier"
       provider-name="Eclipse Nebula">
 
    <description url="http://eclipse.org/nebula">

--- a/widgets/roundedcheckbox/org.eclipse.nebula.widgets.roundedcheckbox.feature/pom.xml
+++ b/widgets/roundedcheckbox/org.eclipse.nebula.widgets.roundedcheckbox.feature/pom.xml
@@ -24,7 +24,7 @@ Contributors:
 
 	<artifactId>org.eclipse.nebula.widgets.roundedcheckbox.feature</artifactId>
 	<packaging>eclipse-feature</packaging>
-	<version>1.0.0-SNAPSHOT</version>
+	<version>1.1.0-SNAPSHOT</version>
 
 	<name>RoundedCheckbox Feature</name>
 

--- a/widgets/roundedcheckbox/org.eclipse.nebula.widgets.roundedcheckbox/META-INF/MANIFEST.MF
+++ b/widgets/roundedcheckbox/org.eclipse.nebula.widgets.roundedcheckbox/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Nebula Rounded Checkbox Widget
 Bundle-SymbolicName: org.eclipse.nebula.widgets.roundedcheckbox
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.1.0.qualifier
 Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.nebula.widgets.opal.commons;bundle-version="1.0.0";visibility:=reexport,

--- a/widgets/roundedcheckbox/org.eclipse.nebula.widgets.roundedcheckbox/pom.xml
+++ b/widgets/roundedcheckbox/org.eclipse.nebula.widgets.roundedcheckbox/pom.xml
@@ -19,6 +19,7 @@ http://www.eclipse.org/legal/epl-v10.html
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.roundedcheckbox</artifactId>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/widgets/roundedcheckbox/org.eclipse.nebula.widgets.roundedcheckbox/src/org/eclipse/nebula/widgets/roundedcheckbox/RoundedCheckbox.java
+++ b/widgets/roundedcheckbox/org.eclipse.nebula.widgets.roundedcheckbox/src/org/eclipse/nebula/widgets/roundedcheckbox/RoundedCheckbox.java
@@ -200,7 +200,7 @@ public class RoundedCheckbox extends Canvas {
 	}
 
 	private Color getAndDisposeColor(int r, int g, int b) {
-		final Color color = new Color(getDisplay(), r, g, b);
+		final Color color = new Color(r, g, b);
 		addDisposeListener(e -> {
 			if (!color.isDisposed()) {
 				color.dispose();

--- a/widgets/roundedswitch/org.eclipse.nebula.widgets.roundedswitch.feature/feature.xml
+++ b/widgets/roundedswitch/org.eclipse.nebula.widgets.roundedswitch.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.nebula.widgets.roundedswitch.feature"
       label="Nebula Rounded Switch Widget"
-      version="1.0.0.qualifier"
+      version="1.1.0.qualifier"
       provider-name="Eclipse Nebula">
 
    <description url="http://eclipse.org/nebula">

--- a/widgets/roundedswitch/org.eclipse.nebula.widgets.roundedswitch.feature/pom.xml
+++ b/widgets/roundedswitch/org.eclipse.nebula.widgets.roundedswitch.feature/pom.xml
@@ -24,7 +24,7 @@ Contributors:
 
 	<artifactId>org.eclipse.nebula.widgets.roundedswitch.feature</artifactId>
 	<packaging>eclipse-feature</packaging>
-	<version>1.0.0-SNAPSHOT</version>
+	<version>1.1.0-SNAPSHOT</version>
 
 	<name>Nebula Rounded Switch widget Feature</name>
 

--- a/widgets/roundedswitch/org.eclipse.nebula.widgets.roundedswitch/META-INF/MANIFEST.MF
+++ b/widgets/roundedswitch/org.eclipse.nebula.widgets.roundedswitch/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Nebula Rounded Switch Widget
 Bundle-SymbolicName: org.eclipse.nebula.widgets.roundedswitch
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.1.0.qualifier
 Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.eclipse.nebula.widgets.roundedswitch

--- a/widgets/roundedswitch/org.eclipse.nebula.widgets.roundedswitch/pom.xml
+++ b/widgets/roundedswitch/org.eclipse.nebula.widgets.roundedswitch/pom.xml
@@ -19,6 +19,7 @@ http://www.eclipse.org/legal/epl-v10.html
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.roundedswitch</artifactId>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/widgets/roundedswitch/org.eclipse.nebula.widgets.roundedswitch/src/org/eclipse/nebula/widgets/roundedswitch/RoundedSwitchConfiguration.java
+++ b/widgets/roundedswitch/org.eclipse.nebula.widgets.roundedswitch/src/org/eclipse/nebula/widgets/roundedswitch/RoundedSwitchConfiguration.java
@@ -48,8 +48,8 @@ class RoundedSwitchConfiguration {
 
 	static RoundedSwitchConfiguration createCheckedDisabledConfiguration(RoundedSwitch parent) {
 		Display display = parent.getDisplay();
-		Color lightGrey = new Color(display, 233, 233, 233);
-		Color darkGrey = new Color(display, 208, 208, 208);
+		Color lightGrey = new Color(233, 233, 233);
+		Color darkGrey = new Color(208, 208, 208);
 		SWTGraphicUtil.addDisposer(parent, lightGrey, darkGrey);
 		RoundedSwitchConfiguration config = new RoundedSwitchConfiguration(lightGrey, darkGrey, lightGrey);
 		return config;
@@ -57,8 +57,8 @@ class RoundedSwitchConfiguration {
 
 	static RoundedSwitchConfiguration createUncheckedDisabledConfiguration(RoundedSwitch parent) {
 		Display display = parent.getDisplay();
-		Color lightGrey = new Color(display, 233, 233, 233);
-		Color darkGrey = new Color(display, 208, 208, 208);
+		Color lightGrey = new Color(233, 233, 233);
+		Color darkGrey = new Color(208, 208, 208);
 		SWTGraphicUtil.addDisposer(parent, lightGrey, darkGrey);
 		RoundedSwitchConfiguration config = new RoundedSwitchConfiguration(lightGrey, darkGrey, lightGrey);
 		return config;

--- a/widgets/segmentedbar/org.eclipse.nebula.widgets.segmentedbar.snippets/META-INF/MANIFEST.MF
+++ b/widgets/segmentedbar/org.eclipse.nebula.widgets.segmentedbar.snippets/META-INF/MANIFEST.MF
@@ -6,5 +6,5 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.nebula.widgets.segmentedbar;bundle-version="1.0.0",
- org.eclipse.swt
+ org.eclipse.swt;bundle-version="[3.115.0,4.0.0)"
 Automatic-Module-Name: org.eclipse.nebula.widgets.segmentedbar.snippets

--- a/widgets/segmentedbar/org.eclipse.nebula.widgets.segmentedbar.snippets/META-INF/MANIFEST.MF
+++ b/widgets/segmentedbar/org.eclipse.nebula.widgets.segmentedbar.snippets/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Nebula Segmented Bar Snippets
 Bundle-SymbolicName: org.eclipse.nebula.widgets.segmentedbar.snippets
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.1.0.qualifier
 Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.nebula.widgets.segmentedbar;bundle-version="1.0.0",

--- a/widgets/segmentedbar/org.eclipse.nebula.widgets.segmentedbar.snippets/pom.xml
+++ b/widgets/segmentedbar/org.eclipse.nebula.widgets.segmentedbar.snippets/pom.xml
@@ -19,6 +19,7 @@ http://www.eclipse.org/legal/epl-v10.html
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.segmentedbar.snippets</artifactId>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/widgets/segmentedbar/org.eclipse.nebula.widgets.segmentedbar.snippets/src/org/eclipse/nebula/widgets/segmentedbar/SegmentedBarSnippet.java
+++ b/widgets/segmentedbar/org.eclipse.nebula.widgets.segmentedbar.snippets/src/org/eclipse/nebula/widgets/segmentedbar/SegmentedBarSnippet.java
@@ -41,11 +41,11 @@ public class SegmentedBarSnippet {
 		lbl1.setLayoutData(new GridData(GridData.BEGINNING, GridData.CENTER, false, false));
 		lbl1.setText("Simple bar");
 
-		Color blue = new Color(display, 70, 130, 180);
-		Color violet = new Color(display, 128, 0, 128);
-		Color lightGreen = new Color(display, 95, 158, 60);
-		Color pink = new Color(display, 240, 128, 180);
-		Color orange = new Color(display, 255, 165, 0);
+		Color blue = new Color(70, 130, 180);
+		Color violet = new Color(128, 0, 128);
+		Color lightGreen = new Color(95, 158, 60);
+		Color pink = new Color(240, 128, 180);
+		Color orange = new Color(255, 165, 0);
 
 		SegmentedBar sb1 = new SegmentedBar(shell, SWT.NONE);
 		sb1.setLayoutData(new GridData(GridData.FILL, GridData.FILL, true, false));

--- a/widgets/tiles/org.eclipse.nebula.widgets.tiles.feature/feature.xml
+++ b/widgets/tiles/org.eclipse.nebula.widgets.tiles.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.nebula.widgets.tiles.feature"
       label="Nebula Tiles Widget"
-      version="1.0.0.qualifier"
+      version="1.1.0.qualifier"
       provider-name="Eclipse Nebula">
 
    <description url="http://eclipse.org/nebula">

--- a/widgets/tiles/org.eclipse.nebula.widgets.tiles.feature/pom.xml
+++ b/widgets/tiles/org.eclipse.nebula.widgets.tiles.feature/pom.xml
@@ -24,7 +24,7 @@ Contributors:
 
 	<artifactId>org.eclipse.nebula.widgets.tiles.feature</artifactId>
 	<packaging>eclipse-feature</packaging>
-	<version>1.0.0-SNAPSHOT</version>
+	<version>1.1.0-SNAPSHOT</version>
 
 	<name>Nebula Tiles widget Feature</name>
 

--- a/widgets/tiles/org.eclipse.nebula.widgets.tiles.snippets/META-INF/MANIFEST.MF
+++ b/widgets/tiles/org.eclipse.nebula.widgets.tiles.snippets/META-INF/MANIFEST.MF
@@ -6,5 +6,5 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.nebula.widgets.tiles;bundle-version="1.0.0",
- org.eclipse.swt
+ org.eclipse.swt;bundle-version="[3.115.0,4.0.0)"
 Automatic-Module-Name: org.eclipse.nebula.widgets.tiles.snippets

--- a/widgets/tiles/org.eclipse.nebula.widgets.tiles.snippets/META-INF/MANIFEST.MF
+++ b/widgets/tiles/org.eclipse.nebula.widgets.tiles.snippets/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Nebula Tiles Snippets
 Bundle-SymbolicName: org.eclipse.nebula.widgets.tiles.snippets
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.1.0.qualifier
 Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.nebula.widgets.tiles;bundle-version="1.0.0",

--- a/widgets/tiles/org.eclipse.nebula.widgets.tiles.snippets/pom.xml
+++ b/widgets/tiles/org.eclipse.nebula.widgets.tiles.snippets/pom.xml
@@ -19,6 +19,7 @@ http://www.eclipse.org/legal/epl-v10.html
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.tiles.snippets</artifactId>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/widgets/tiles/org.eclipse.nebula.widgets.tiles.snippets/src/org/eclipse/nebula/widgets/tiles/Example1.java
+++ b/widgets/tiles/org.eclipse.nebula.widgets.tiles.snippets/src/org/eclipse/nebula/widgets/tiles/Example1.java
@@ -163,7 +163,7 @@ public class Example1 {
 	 */
 	private static DecoratorColor<Integer> getDecoratorForegroundColor(final Tiles<Integer> tiles) {
 		
-		final Color black = new Color(tiles.getDisplay(), 0, 0, 0);
+		final Color black = new Color(0, 0, 0);
 		
 		final DecoratorColor<Integer> decorator = new DecoratorColor<Integer>() {
 			@Override
@@ -198,8 +198,8 @@ public class Example1 {
 	 */
 	private static DecoratorColor<Integer> getDecoratorLineColor(final Tiles<Integer> tiles) {
 		
-		final Color black = new Color(tiles.getDisplay(), 0, 0, 0);
-		final Color blue = new Color(tiles.getDisplay(), 0, 0, 255);
+		final Color black = new Color(0, 0, 0);
+		final Color blue = new Color(0, 0, 255);
 		
 		final DecoratorColor<Integer> decorator = new DecoratorColor<Integer>() {
 			@Override

--- a/widgets/tiles/org.eclipse.nebula.widgets.tiles.snippets/src/org/eclipse/nebula/widgets/tiles/Example4.java
+++ b/widgets/tiles/org.eclipse.nebula.widgets.tiles.snippets/src/org/eclipse/nebula/widgets/tiles/Example4.java
@@ -142,7 +142,7 @@ public class Example4 {
 	 */
 	private static DecoratorColor<Integer> getDecoratorForegroundColor(final Tiles<Integer> tiles) {
 
-		final Color black = new Color(tiles.getDisplay(), 0, 0, 0);
+		final Color black = new Color(0, 0, 0);
 
 		final DecoratorColor<Integer> decorator = new DecoratorColor<Integer>() {
 			@Override
@@ -177,8 +177,8 @@ public class Example4 {
 	 */
 	private static DecoratorColor<Integer> getDecoratorLineColor(final Tiles<Integer> tiles) {
 
-		final Color black = new Color(tiles.getDisplay(), 0, 0, 0);
-		final Color blue = new Color(tiles.getDisplay(), 0, 0, 255);
+		final Color black = new Color(0, 0, 0);
+		final Color blue = new Color(0, 0, 255);
 
 		final DecoratorColor<Integer> decorator = new DecoratorColor<Integer>() {
 			@Override

--- a/widgets/tiles/org.eclipse.nebula.widgets.tiles/META-INF/MANIFEST.MF
+++ b/widgets/tiles/org.eclipse.nebula.widgets.tiles/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Nebula Tiles Widget
 Bundle-SymbolicName: org.eclipse.nebula.widgets.tiles
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.1.0.qualifier
 Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.eclipse.nebula.widgets.tiles

--- a/widgets/tiles/org.eclipse.nebula.widgets.tiles/pom.xml
+++ b/widgets/tiles/org.eclipse.nebula.widgets.tiles/pom.xml
@@ -19,6 +19,7 @@ http://www.eclipse.org/legal/epl-v10.html
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.tiles</artifactId>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/widgets/tiles/org.eclipse.nebula.widgets.tiles/src/org/eclipse/nebula/widgets/tiles/FrameStatic.java
+++ b/widgets/tiles/org.eclipse.nebula.widgets.tiles/src/org/eclipse/nebula/widgets/tiles/FrameStatic.java
@@ -150,9 +150,9 @@ class FrameStatic<T> extends Frame<T> implements Cloneable  {
 		this.tiles = tiles;
 
 		// Prepare resources
-		final Color backgroundColor = new Color(tiles.getDisplay(), 255, 255, 255);
-		final Color lineColor = new Color(tiles.getDisplay(), 0, 0, 0);
-		final Color foregroundColor = new Color(tiles.getDisplay(), 0, 0, 0);
+		final Color backgroundColor = new Color(255, 255, 255);
+		final Color lineColor = new Color(0, 0, 0);
+		final Color foregroundColor = new Color(0, 0, 0);
 
 		// Initial settings
 		this.background = tiles.getBackground();

--- a/widgets/tiles/org.eclipse.nebula.widgets.tiles/src/org/eclipse/nebula/widgets/tiles/Gradient.java
+++ b/widgets/tiles/org.eclipse.nebula.widgets.tiles/src/org/eclipse/nebula/widgets/tiles/Gradient.java
@@ -110,7 +110,7 @@ public class Gradient {
 		final Color[] result = new Color[steps];
 		for (int y=0; y<steps; y++){
 			final int rgb = legend.getRGB(0, y);
-			result[y] = new Color(tiles.getDisplay(), rgb >> 16 & 0x000000ff, rgb >> 8 & 0x000000ff, rgb & 0x000000ff);
+			result[y] = new Color(rgb >> 16 & 0x000000ff, rgb >> 8 & 0x000000ff, rgb & 0x000000ff);
 		}
 
 		// Return

--- a/widgets/tiles/org.eclipse.nebula.widgets.tiles/src/org/eclipse/nebula/widgets/tiles/GradientGrayscale.java
+++ b/widgets/tiles/org.eclipse.nebula.widgets.tiles/src/org/eclipse/nebula/widgets/tiles/GradientGrayscale.java
@@ -32,9 +32,9 @@ public class GradientGrayscale extends Gradient{
 	 */
 	private static final Color[] getColors(final Tiles<?> tiles){
 		final Display device = tiles.getDisplay();
-		final Color[] colors = new Color[]{	new Color(device, 0, 0, 0),
-				new Color(device, 128, 128, 128),
-				new Color(device, 255, 255, 255)};
+		final Color[] colors = new Color[]{	new Color(0, 0, 0),
+				new Color(128, 128, 128),
+				new Color(255, 255, 255)};
 		tiles.addDisposeListener(arg0 -> {
 			for (final Color c : colors) {
 				if (!c.isDisposed()) {

--- a/widgets/tiles/org.eclipse.nebula.widgets.tiles/src/org/eclipse/nebula/widgets/tiles/GradientHeatscale.java
+++ b/widgets/tiles/org.eclipse.nebula.widgets.tiles/src/org/eclipse/nebula/widgets/tiles/GradientHeatscale.java
@@ -31,12 +31,12 @@ public class GradientHeatscale extends Gradient{
 	 */
 	private static final Color[] getColors(final Tiles<?> tiles){
 		final Display device = tiles.getDisplay();
-		final Color[] colors = new Color[]{	new Color(device, 0, 0, 255),
-				new Color(device, 0, 255, 255),
-				new Color(device, 0, 200, 0),
-				new Color(device, 255, 255, 0),
-				new Color(device, 255, 69, 0),
-				new Color(device, 255, 0, 0)};
+		final Color[] colors = new Color[]{	new Color(0, 0, 255),
+				new Color(0, 255, 255),
+				new Color(0, 200, 0),
+				new Color(255, 255, 0),
+				new Color(255, 69, 0),
+				new Color(255, 0, 0)};
 
 		tiles.addDisposeListener(arg0 -> {
 			for (final Color c : colors) {

--- a/widgets/tiles/org.eclipse.nebula.widgets.tiles/src/org/eclipse/nebula/widgets/tiles/Tiles.java
+++ b/widgets/tiles/org.eclipse.nebula.widgets.tiles/src/org/eclipse/nebula/widgets/tiles/Tiles.java
@@ -99,7 +99,7 @@ public class Tiles<T> extends Canvas {
 		addMouseListener(mouseListener);
 		addMouseMoveListener(mouseMoveListener);
 		addControlListener(resizeListener);
-		this.black = new Color(getDisplay(), 0, 0, 0);
+		this.black = new Color(0, 0, 0);
 		getDisplay().timerExec(settings.getDelta(), animation);
 	}
 

--- a/widgets/treemapper/org.eclipse.nebula.widgets.treemapper.examples/META-INF/MANIFEST.MF
+++ b/widgets/treemapper/org.eclipse.nebula.widgets.treemapper.examples/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Nebula Tree Mapper Examples
 Bundle-SymbolicName: org.eclipse.nebula.widgets.treemapper.examples;singleton:=true
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.1.0.qualifier
 Bundle-Vendor: Eclipse Nebula
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.nebula.widgets.treemapper,

--- a/widgets/treemapper/org.eclipse.nebula.widgets.treemapper.examples/META-INF/MANIFEST.MF
+++ b/widgets/treemapper/org.eclipse.nebula.widgets.treemapper.examples/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Vendor: Eclipse Nebula
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.nebula.widgets.treemapper,
  org.eclipse.nebula.examples;bundle-version="1.0.4",
- org.eclipse.swt,
+ org.eclipse.swt;bundle-version="[3.115.0,4.0.0)",
  org.eclipse.jface
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy

--- a/widgets/treemapper/org.eclipse.nebula.widgets.treemapper.examples/pom.xml
+++ b/widgets/treemapper/org.eclipse.nebula.widgets.treemapper.examples/pom.xml
@@ -23,6 +23,7 @@ Contributors:
 	</parent>
 
 	<artifactId>org.eclipse.nebula.widgets.treemapper.examples</artifactId>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/widgets/treemapper/org.eclipse.nebula.widgets.treemapper.examples/src/org/eclipse/nebula/widgets/treemapper/examples/TreeMapperExampleTab.java
+++ b/widgets/treemapper/org.eclipse.nebula.widgets.treemapper.examples/src/org/eclipse/nebula/widgets/treemapper/examples/TreeMapperExampleTab.java
@@ -66,8 +66,8 @@ public class TreeMapperExampleTab extends AbstractExampleTab {
 
 	@Override
 	public Control createControl(Composite parent) {
-		Color defaultColor = new Color(parent.getShell().getDisplay(), new RGB(247, 206, 206));
-		Color selectedColor = new Color(parent.getShell().getDisplay(), new RGB(147, 86, 111));
+		Color defaultColor = new Color(new RGB(247, 206, 206));
+		Color selectedColor = new Color(new RGB(147, 86, 111));
 		TreeMapperUIConfigProvider uiConfig = new TreeMapperUIConfigProvider(defaultColor, 1, selectedColor, 3);
 		
 		parent.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));

--- a/widgets/visualization/org.eclipse.nebula.visualization.feature/feature.xml
+++ b/widgets/visualization/org.eclipse.nebula.visualization.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.nebula.visualization.feature"
       label="%featureName"
-      version="2.1.0.qualifier"
+      version="2.2.0.qualifier"
       provider-name="%provider">
 
    <description url="%featureDescriptionURL">

--- a/widgets/visualization/org.eclipse.nebula.visualization.feature/pom.xml
+++ b/widgets/visualization/org.eclipse.nebula.visualization.feature/pom.xml
@@ -24,7 +24,7 @@ Contributors:
 
 	<artifactId>org.eclipse.nebula.visualization.feature</artifactId>
 	<packaging>eclipse-feature</packaging>
-	<version>2.1.0-SNAPSHOT</version>
+	<version>2.2.0-SNAPSHOT</version>
 
 	<name>Nebula Visualization</name>
 

--- a/widgets/visualization/org.eclipse.nebula.visualization.xygraph/META-INF/MANIFEST.MF
+++ b/widgets/visualization/org.eclipse.nebula.visualization.xygraph/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.eclipse.nebula.visualization.xygraph
 Bundle-Version: 3.1.1.qualifier
 Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
-Require-Bundle: org.eclipse.swt,
+Require-Bundle: org.eclipse.swt;bundle-version="[3.115.0,4.0.0)",
  org.eclipse.draw2d,
  org.eclipse.jface,
  org.eclipse.core.runtime

--- a/widgets/visualization/org.eclipse.nebula.visualization.xygraph/META-INF/MANIFEST.MF
+++ b/widgets/visualization/org.eclipse.nebula.visualization.xygraph/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Nebula Visualization XY Graph
 Bundle-SymbolicName: org.eclipse.nebula.visualization.xygraph
-Bundle-Version: 3.1.1.qualifier
+Bundle-Version: 3.2.0.qualifier
 Bundle-Vendor: Eclipse Nebula
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.swt;bundle-version="[3.115.0,4.0.0)",

--- a/widgets/visualization/org.eclipse.nebula.visualization.xygraph/pom.xml
+++ b/widgets/visualization/org.eclipse.nebula.visualization.xygraph/pom.xml
@@ -24,7 +24,7 @@ Contributors:
 
 	<artifactId>org.eclipse.nebula.visualization.xygraph</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>3.1.1-SNAPSHOT</version>
+	<version>3.2.0-SNAPSHOT</version>
 	
 	<name>Nebula Visualization XY-Graph</name>
 

--- a/widgets/visualization/org.eclipse.nebula.visualization.xygraph/src/org/eclipse/nebula/visualization/xygraph/figures/Trace.java
+++ b/widgets/visualization/org.eclipse.nebula.visualization.xygraph/src/org/eclipse/nebula/visualization/xygraph/figures/Trace.java
@@ -381,7 +381,7 @@ public class Trace extends Figure implements IDataProviderListener, IAxisListene
 			graphics.setAlpha(areaAlpha);
 		} else {
 			final float[] hsb = errorBarColor.getRGB().getHSB();
-			lighter = new Color(Display.getCurrent(), new RGB(hsb[0], hsb[1] * areaAlpha / 255, 1.0f));
+			lighter = new Color(new RGB(hsb[0], hsb[1] * areaAlpha / 255, 1.0f));
 			graphics.setBackgroundColor(lighter);
 		}
 

--- a/widgets/visualization/org.eclipse.nebula.visualization.xygraph/src/org/eclipse/nebula/visualization/xygraph/util/SingleSourceHelperImpl.java
+++ b/widgets/visualization/org.eclipse.nebula.visualization.xygraph/src/org/eclipse/nebula/visualization/xygraph/util/SingleSourceHelperImpl.java
@@ -46,7 +46,7 @@ public class SingleSourceHelperImpl extends SingleSourceHelper2 {
 		Image image = new Image(Display.getCurrent(), w, h);
 
 		final GC gc = GraphicsUtil.createGC(image);
-		final Color titleColor = new Color(Display.getCurrent(), color);
+		final Color titleColor = new Color(color);
 		RGB transparentRGB = new RGB(240, 240, 240);
 
 		gc.setBackground(XYGraphMediaFactory.getInstance().getColor(transparentRGB));


### PR DESCRIPTION
## Summary
- Replaces all `new Color(Device/Display, ...)` constructor calls with the modern `new Color(...)` equivalents across 64 files
- The `Color(Device, int, int, int)`, `Color(Device, RGB)`, and `Color(Device, RGBA)` constructors are being deprecated in eclipse-platform/eclipse.platform.swt#3233
- This reduces boilerplate, avoids NPE risks on non-UI threads, and simplifies resource management

## Test plan
- [ ] Verify the project compiles successfully
- [ ] Verify no regressions in color rendering across widgets

🤖 Generated with [Claude Code](https://claude.com/claude-code)