### PR TITLE
Update CI agent label from centos-latest to ubuntu-latest

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 pipeline {
   agent {
-    label "centos-latest"
+    label "ubuntu-latest"
   }
 
   options {


### PR DESCRIPTION
## Summary
- Updates the Jenkins agent label from `centos-latest` to `ubuntu-latest`
- The `centos-latest` agent does not properly expose Java 21 to the Tycho/OSGi resolution context, causing builds to fail with `a.jre.javase 17.0.0` even though JDK 21 is installed
- This fixes the build failure seen in PR #692 and likely affects all current builds

## Test plan
- [ ] Verify the CI build passes with the new agent label

🤖 Generated with [Claude Code](https://claude.com/claude-code)