### PR TITLE
Update org.eclipse.nebula.feature to version 3.5.0

### DIFF
--- a/releng/org.eclipse.nebula.feature/feature.xml
+++ b/releng/org.eclipse.nebula.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.nebula.feature"
       label="Nebula All Mature Widgets SDK"
-      version="3.4.0.qualifier"
+      version="3.5.0.qualifier"
       provider-name="Eclipse Nebula">
 
    <description url="http://eclipse.org/nebula">

--- a/releng/org.eclipse.nebula.feature/pom.xml
+++ b/releng/org.eclipse.nebula.feature/pom.xml
@@ -24,7 +24,7 @@ Contributors:
 	</parent>
 
 	<artifactId>org.eclipse.nebula.feature</artifactId>
-	<version>3.4.0-SNAPSHOT</version>
+	<version>3.5.0-SNAPSHOT</version>
 	<packaging>eclipse-feature</packaging>
 
 	<name>Eclipse Nebula Feature</name>

--- a/widgets/geomap/org.eclipse.nebula.widgets.geomap.tests/.settings/org.eclipse.jdt.core.prefs
+++ b/widgets/geomap/org.eclipse.nebula.widgets.geomap.tests/.settings/org.eclipse.jdt.core.prefs
@@ -5,7 +5,6 @@ org.eclipse.jdt.core.compiler.compliance=11
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
 org.eclipse.jdt.core.compiler.source=11

--- a/widgets/pagination/org.eclipse.nebula.widgets.pagination.example/.settings/org.eclipse.jdt.core.prefs
+++ b/widgets/pagination/org.eclipse.nebula.widgets.pagination.example/.settings/org.eclipse.jdt.core.prefs
@@ -10,7 +10,6 @@ org.eclipse.jdt.core.compiler.debug.sourceFile=generate
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
 org.eclipse.jdt.core.compiler.source=11

--- a/widgets/pagination/org.eclipse.nebula.widgets.pagination.feature/.settings/org.eclipse.jdt.core.prefs
+++ b/widgets/pagination/org.eclipse.nebula.widgets.pagination.feature/.settings/org.eclipse.jdt.core.prefs
@@ -4,5 +4,4 @@ org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
 org.eclipse.jdt.core.compiler.compliance=11
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.source=1.8

--- a/widgets/pagination/org.eclipse.nebula.widgets.pagination.snippets/.settings/org.eclipse.jdt.core.prefs
+++ b/widgets/pagination/org.eclipse.nebula.widgets.pagination.snippets/.settings/org.eclipse.jdt.core.prefs
@@ -10,7 +10,6 @@ org.eclipse.jdt.core.compiler.debug.sourceFile=generate
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
 org.eclipse.jdt.core.compiler.source=11

--- a/widgets/pagination/org.eclipse.nebula.widgets.pagination.tests/.settings/org.eclipse.jdt.core.prefs
+++ b/widgets/pagination/org.eclipse.nebula.widgets.pagination.tests/.settings/org.eclipse.jdt.core.prefs
@@ -10,7 +10,6 @@ org.eclipse.jdt.core.compiler.debug.sourceFile=generate
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
 org.eclipse.jdt.core.compiler.source=11

--- a/widgets/pagination/org.eclipse.nebula.widgets.pagination/.settings/org.eclipse.jdt.core.prefs
+++ b/widgets/pagination/org.eclipse.nebula.widgets.pagination/.settings/org.eclipse.jdt.core.prefs
@@ -10,7 +10,6 @@ org.eclipse.jdt.core.compiler.debug.sourceFile=generate
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
 org.eclipse.jdt.core.compiler.source=11

--- a/widgets/picture/org.eclipse.nebula.widgets.picture.example/.settings/org.eclipse.jdt.core.prefs
+++ b/widgets/picture/org.eclipse.nebula.widgets.picture.example/.settings/org.eclipse.jdt.core.prefs
@@ -5,7 +5,6 @@ org.eclipse.jdt.core.compiler.compliance=11
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
 org.eclipse.jdt.core.compiler.source=11

--- a/widgets/picture/org.eclipse.nebula.widgets.picture.feature/.settings/org.eclipse.jdt.core.prefs
+++ b/widgets/picture/org.eclipse.nebula.widgets.picture.feature/.settings/org.eclipse.jdt.core.prefs
@@ -4,5 +4,4 @@ org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
 org.eclipse.jdt.core.compiler.compliance=11
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.source=1.8

--- a/widgets/picture/org.eclipse.nebula.widgets.picture.snippets/.settings/org.eclipse.jdt.core.prefs
+++ b/widgets/picture/org.eclipse.nebula.widgets.picture.snippets/.settings/org.eclipse.jdt.core.prefs
@@ -10,7 +10,6 @@ org.eclipse.jdt.core.compiler.debug.sourceFile=generate
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
 org.eclipse.jdt.core.compiler.source=11

--- a/widgets/picture/org.eclipse.nebula.widgets.picture/.settings/org.eclipse.jdt.core.prefs
+++ b/widgets/picture/org.eclipse.nebula.widgets.picture/.settings/org.eclipse.jdt.core.prefs
@@ -10,7 +10,6 @@ org.eclipse.jdt.core.compiler.debug.sourceFile=generate
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
 org.eclipse.jdt.core.compiler.release=enabled
 org.eclipse.jdt.core.compiler.source=11


### PR DESCRIPTION
- Remove project-specific org.eclipse.jdt.core.compiler.problem.forbiddenReference from all org.eclipse.jdt.core.prefs to avoid new 4.40 PDE errors.

https://github.com/EclipseNebula/nebula/issues/702